### PR TITLE
DD-1094. Fixed viewing old reports

### DIFF
--- a/src/AppBundle/Controller/ReportController.php
+++ b/src/AppBundle/Controller/ReportController.php
@@ -221,10 +221,6 @@ class ReportController extends Controller
         $util = $this->get('util'); /* @var $util \AppBundle\Service\Util */
         
         $report = $util->getReport($reportId, $this->getUser()->getId());
-        $violations = $this->get('validator')->validate($report, ['due', 'readyforSubmission', 'reviewedAndChecked', 'submitted']);
-        if (count($violations)) {
-            throw new \RuntimeException($violations->getIterator()->current()->getMessage());
-        }
         $client = $util->getClient($report->getClient(), $this->getUser()->getId());
         
         $assets = $apiClient->getEntities('Asset','get_report_assets', [ 'parameters' => ['id' => $reportId ]]);
@@ -252,10 +248,6 @@ class ReportController extends Controller
         $util = $this->get('util');
         
         $report = $util->getReport($reportId, $this->getUser()->getId());
-        $violations = $this->get('validator')->validate($report, ['due', 'readyforSubmission', 'reviewedAndChecked', 'submitted']);
-        if (count($violations)) {
-            throw new \RuntimeException($violations->getIterator()->current()->getMessage());
-        }
         $client = $util->getClient($report->getClient(), $this->getUser()->getId());
         
         $assets = $apiClient->getEntities('Asset','get_report_assets', [ 'parameters' => ['id' => $reportId ]]);

--- a/src/AppBundle/Resources/views/Report/display.html.twig
+++ b/src/AppBundle/Resources/views/Report/display.html.twig
@@ -62,11 +62,13 @@
 
     {% if reportType is sameas("propertyAndAffairs") %}
 
+        {% if report.safeguarding is not null %}
         <div class="external-report-section" id="safeguarding-section">
             {% include 'AppBundle:Safeguard:summary.html.twig' with {
                 'safeguarding': report.safeguarding
             } %}
         </div>
+        {% endif %}
 
         <div class="external-report-section" id="accounts-section">
             {% include 'AppBundle:Components/Page:_page-section-title.html.twig' with {

--- a/src/AppBundle/Resources/views/Report/formatted.html.twig
+++ b/src/AppBundle/Resources/views/Report/formatted.html.twig
@@ -21,9 +21,11 @@
                 {% include 'AppBundle:Report:Formatted/_client_information.html.twig' %}
                 {% include 'AppBundle:Report:Formatted/_decisions.html.twig' %}
                 {% include 'AppBundle:Report:Formatted/_contacts.html.twig' %}
-                {% include 'AppBundle:Report:Formatted/_safeguarding.html.twig' with {
-                    'safeguarding': report.safeguarding
-                } %}
+                {% if report.safeguarding is not null %}
+                    {% include 'AppBundle:Report:Formatted/_safeguarding.html.twig' with {
+                        'safeguarding': report.safeguarding
+                    } %}
+                {% endif %}
                 {% include 'AppBundle:Report:Formatted/_accounts.html.twig' %}
                 {% include 'AppBundle:Report:Formatted/_assets.html.twig' %}
                 


### PR DESCRIPTION
viewing old reports added before safeguarding produced an error when the user tried to view them. This is because they did not pass the validation rules for a new report and there was no check to see if a safeguarding value was null or not.