### PR TITLE
session keep alive no popup on ff

### DIFF
--- a/src/AppBundle/Controller/IndexController.php
+++ b/src/AppBundle/Controller/IndexController.php
@@ -110,7 +110,7 @@ class IndexController extends AbstractController
      * keep session alive. Called from session timeout dialog
      * 
      * @Route("session-keep-alive", name="session-keep-alive")
-     * @Method({"POST"})
+     * @Method({"GET"})
      */
     public function sessionKeepAliveAction(Request $request)
     {

--- a/src/AppBundle/Resources/assets/javascripts/sessionTimeoutDialog.js
+++ b/src/AppBundle/Resources/assets/javascripts/sessionTimeoutDialog.js
@@ -56,7 +56,7 @@ var SessionTimeoutDialog = function (options) {
     };
 
     this.keepSessionAlive = function () {
-        $.post(this.keepSessionAliveUrl);
+        $.get(this.keepSessionAliveUrl + '?refresh=' + Date.now());
     };
 
 };


### PR DESCRIPTION
@ztolley I've changed the keep alive URL to be a GET, Firefox was otherwise asking to confirm with an additional popup to submit (POST) the data. It initially was a POST to avoid potential proxy caching, but I've added a timestamp to the URL so that won't be a problem