### PR TITLE
Updated base container to one with the fix to gzip javascript

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.dsd.io/opguk/php-fpm:0.1.128
+FROM registry.service.dsd.io/opguk/php-fpm:0.1.178
 
 # adds nodejs pkg repository
 RUN  curl --silent --location https://deb.nodesource.com/setup_4.x | bash -


### PR DESCRIPTION
This change will ensure javascript is gzipped in transit. It uses a container that incorporates the following change:

https://github.com/ministryofjustice/opg-docker/commit/88b0fef40ddf4fe02d7a9f14389b970097dbec05

@elvisciotti - this is the change that we discussed on Slack (2016-09-28 11:56)