### PR TITLE
OPGOPS-1836: update docker php-fpm to 0.1.213

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.service.opg.digital/opguk/php-fpm:0.1.209
+FROM registry.service.opg.digital/opguk/php-fpm:0.1.213
 
 # adds nodejs pkg repository
 RUN  curl --silent --location https://deb.nodesource.com/setup_4.x | bash -


### PR DESCRIPTION
From: https://opgtransform.atlassian.net/browse/OPGOPS-1836

updates php-fpm to version 0.1.213