### PR TITLE
DDPB-1165: JavaScript fix for duplicate form submissions

### DIFF
--- a/src/AppBundle/Resources/assets/javascripts/modules/submit.js
+++ b/src/AppBundle/Resources/assets/javascripts/modules/submit.js
@@ -1,0 +1,14 @@
+$(function()
+{
+    $('form').submit(function(){
+        //The disabling of the button needs to happen after submission has taken place otherwise Symfony code like:
+        //$form->get('save')->isClicked() will not work.
+        //This is because disabling this button happens before form submission so its value is not passed as part of the post
+        //Adding a very short timeout prevents this problem and still prevents multiple form submissions
+        setTimeout(function(){
+            $('form').find("button[type='submit']").prop('disabled', true);
+            $('form').find("input[type='submit']").prop('disabled', true);
+        }, 1);
+        return true;
+    });
+});


### PR DESCRIPTION
Added javascript to disable the form submit buttons after submission. This prevents the creation of duplicate entries in most cases.

It's not watertight. Ideally we'd use a single use token in the form to make the requests idempotent but that's outside the scope of this ticket.

You may need to run docker exec -it opgdigidepsdocker_frontend_1 gulp to test this locally.