### PR TITLE
DDPB-1204: ACL for client settings plus behat tests

### DIFF
--- a/app/config/security.yml
+++ b/app/config/security.yml
@@ -71,6 +71,9 @@ security:
     access_control:
         # /admin accessible only from ADMIN, super users and AD users
         - { path: ^/admin, roles: [ROLE_ADMIN, ROLE_AD] }
+        # client settings not available to PA users
+        - { path: ^/settings, roles: [ROLE_DEPUTY, ROLE_ADMIN, ROLE_AD] }
+        - { path: ^/user-account/, roles: [ROLE_DEPUTY, ROLE_ADMIN, ROLE_AD] }
         - { path: ^/ad, roles: [ROLE_AD] }
         - { path: ^/pa/team/add, roles: [ROLE_PA, ROLE_PA_ADMIN] }
         - { path: ^/pa/team/edit, roles: [ROLE_PA, ROLE_PA_ADMIN, ROLE_PA_TEAM_MEMBER] }

--- a/tests/behat/bootstrap/AuthenticationTrait.php
+++ b/tests/behat/bootstrap/AuthenticationTrait.php
@@ -54,6 +54,17 @@ trait AuthenticationTrait
     }
 
     /**
+     * @Then the URL :url should be forbidden
+     */
+    public function theUrlShouldBeForbidden($url)
+    {
+        $previousUrl = $this->getSession()->getCurrentUrl();
+        $this->visit($url);
+        $this->assertResponseStatus(403);
+        $this->visit($previousUrl);
+    }
+
+    /**
      * @Then I expire the session
      */
     public function iExpireTheSession()

--- a/tests/behat/features/pa/07-acl.feature
+++ b/tests/behat/features/pa/07-acl.feature
@@ -36,3 +36,12 @@ Feature: PA cannot access other's PA's reports and clients
     But I should not see the "client-1000010" region
     When I go to the URL previously saved as "report-for-client-1000010.url"
     Then the response status code should be 500
+
+  Scenario: PA user cannot edit client
+    Given I am logged in as "behat-pa1@publicguardian.gsi.gov.uk" with password "Abcd1234"
+    Then the URL "/settings" should be forbidden
+    And the URL "/user-account/client-show" should be forbidden
+    And the URL "/user-account/client-edit" should be forbidden
+    And the URL "/user-account/user-show" should be forbidden
+    And the URL "/user-account/user-edit" should be forbidden
+    And the URL "/user-account/password-edit" should be forbidden


### PR DESCRIPTION
I checked the controllers in the API and they seem to have the correct security set up. Either they are only accessible by non PA users or they verify that you own the id of the user you are trying to edit.