### PR TITLE
DDPB-1209: Attach submitted report pdf to PA email

### DIFF
--- a/src/AppBundle/Controller/Report/ReportController.php
+++ b/src/AppBundle/Controller/Report/ReportController.php
@@ -185,8 +185,13 @@ class ReportController extends AbstractController
             $newReport = $this->getRestClient()->get('report/' . $newReportId['newReportId'], 'Report\\Report');
 
             //send confirmation email
-            $reportConfirmEmail = $this->getMailFactory()->createReportSubmissionConfirmationEmail($this->getUser(), $report, $newReport);
-            $this->getMailSender()->send($reportConfirmEmail, ['text', 'html']);
+            if ($user->isDeputyPa()) {
+                $reportConfirmEmail = $this->getMailFactory()->createPaReportSubmissionConfirmationEmail($this->getUser(), $report, $newReport, $pdfBinaryContent);
+                $this->getMailSender()->send($reportConfirmEmail, ['text', 'html'], 'secure-smtp');
+            } else {
+                $reportConfirmEmail = $this->getMailFactory()->createReportSubmissionConfirmationEmail($this->getUser(), $report, $newReport);
+                $this->getMailSender()->send($reportConfirmEmail, ['text', 'html']);
+            }
 
             return $this->redirect($this->generateUrl('report_submit_confirmation', ['reportId' => $report->getId()]));
         }

--- a/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
+++ b/src/AppBundle/Resources/views/Email/report-submission-confirm.html.twig
@@ -12,10 +12,14 @@
 
     <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">We’re in the process of reviewing your report, and will contact you when this has been done. </p>
 
-     <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;"><strong>Download a pdf of your report</strong></p>
+    {% if app.user.isDeputyPa() %}
+        <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">A pdf copy of the report is attached to this email for your records.</p>
+    {% else %}
+        <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;"><strong>Download a pdf of your report</strong></p>
 
-    <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">To view and download a copy of the report for your records, <a style="word-wrap: break-word;" href="{{ homepageUrl }}">sign back into the deputy report service</a>. Go to the ‘Your reports' homepage, where you’ll find a link to download a pdf of your report.
-    </p>
+        <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">To view and download a copy of the report for your records, <a style="word-wrap: break-word;" href="{{ homepageUrl }}">sign back into the deputy report service</a>. Go to the ‘Your reports' homepage, where you’ll find a link to download a pdf of your report.
+        </p>
+    {% endif %}
 
     <p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;"><strong>What happens next</strong></p>
 

--- a/src/AppBundle/Resources/views/Email/report-submission-confirm.text.twig
+++ b/src/AppBundle/Resources/views/Email/report-submission-confirm.text.twig
@@ -5,10 +5,14 @@ Thank you for submitting your annual deputy report for {{ submittedReport.startD
 We’re in the process of reviewing your report, and will contact you when this has been done.
 
 
+{% if app.user.isDeputyPa() %}
+A pdf copy of the report is attached to this email for your records.
+{% else %}
 Download a pdf of your report
 -----------------------------
 
 To view and download a copy of the report for your records, sign back into the deputy report service {{ homepageUrl }}. Go to the ‘Your reports' homepage, where you’ll find a link to download a pdf of your report.
+{% endif %}
 
 
 What happens next


### PR DESCRIPTION
PA submission email now has the PDF attached. I've also reworded the email text to reflect this.

Tested and this works correctly. Email received containing the pdf.

All behat tests pass locally.