### PR TITLE
Ddpb 750 bank account name

### DIFF
--- a/src/AppBundle/Controller/Report/BankAccountController.php
+++ b/src/AppBundle/Controller/Report/BankAccountController.php
@@ -52,13 +52,11 @@ class BankAccountController extends AbstractController
         $report = $this->getReportIfNotSubmitted($reportId, self::$jmsGroups);
         $fromPage = $request->get('from');
 
-
         $stepRedirector = $this->stepRedirector()
             ->setRoutes('bank_accounts', 'bank_accounts_step', 'bank_accounts_summary')
             ->setFromPage($fromPage)
             ->setCurrentStep($step)->setTotalSteps($totalSteps)
             ->setRouteBaseParams(['reportId'=>$reportId, 'accountId' => $accountId]);
-
 
         // create (add mode) or load account (edit mode)
         if ($accountId) {

--- a/src/AppBundle/Entity/Odr/BankAccount.php
+++ b/src/AppBundle/Entity/Odr/BankAccount.php
@@ -23,10 +23,15 @@ class BankAccount
         'other_no_sortcode' => 'Other type of account without sort code',
     ];
 
-    private static $typesRequiringSortCode = [
+    private static $typesNotRequiringSortCode = [
         'postoffice',
         'cfo',
         'other_no_sortcode'
+    ];
+
+    private static $typesNotRequiringBankName = [
+        'postoffice',
+        'cfo'
     ];
 
     /**
@@ -258,9 +263,19 @@ class BankAccount
      *
      * @return string
      */
-    public function requiresBankNameAndSortCode()
+    public function requiresSortCode()
     {
-        return !in_array($this->getAccountType(), self::$typesRequiringSortCode);
+        return !in_array($this->getAccountType(), self::$typesNotRequiringSortCode);
+    }
+
+    /**
+     * Bank name required.
+     *
+     * @return string
+     */
+    public function requiresBankName()
+    {
+        return !in_array($this->getAccountType(), self::$typesNotRequiringBankName);
     }
 
     public function getIsJointAccount()

--- a/src/AppBundle/Entity/Report/BankAccount.php
+++ b/src/AppBundle/Entity/Report/BankAccount.php
@@ -26,10 +26,15 @@ class BankAccount
         'other_no_sortcode' => 'Other type of account without sort code',
     ];
 
-    private static $typesRequiringSortCode = [
+    private static $typesNotRequiringSortCode = [
         'postoffice',
         'cfo',
         'other_no_sortcode'
+    ];
+
+    private static $typesNotRequiringBankName = [
+        'postoffice',
+        'cfo'
     ];
 
     /**
@@ -312,9 +317,20 @@ class BankAccount
      *
      * @return string
      */
-    public function requiresBankNameAndSortCode()
+    public function requiresSortCode()
     {
-        return !in_array($this->getAccountType(), self::$typesRequiringSortCode);
+        return !in_array($this->getAccountType(), self::$typesNotRequiringSortCode);
+    }
+
+
+    /**
+     * Bank name required.
+     *
+     * @return string
+     */
+    public function requiresBankName()
+    {
+        return !in_array($this->getAccountType(), self::$typesNotRequiringBankName);
     }
 
     /**

--- a/src/AppBundle/Form/Odr/BankAccountType.php
+++ b/src/AppBundle/Form/Odr/BankAccountType.php
@@ -84,13 +84,18 @@ class BankAccountType extends AbstractType
         $resolver->setDefaults([
             'translation_domain' => 'odr-bank-accounts',
             'validation_groups'  => function (FormInterface $form) {
-                $requiresBankNameAndSortCode = $form->getData()->requiresBankNameAndSortCode();
+
+                $step2Options = ['bank-account-number', 'bank-account-is-joint'];
+                if ($form->getData()->requiresSortCode()) {
+                    $step2Options[] = 'sortcode';
+                }
+                if ($form->getData()->requiresBankName()) {
+                    $step2Options[] = 'bank-account-name';
+                }
 
                 return [
                     1 => ['bank-account-type'],
-                    2 => $requiresBankNameAndSortCode ?
-                        ['bank-account-name', 'sortcode', 'bank-account-number', 'bank-account-is-joint']
-                        : ['bank-account-number', 'bank-account-is-joint'],
+                    2 => $step2Options,
                     3 => ['bank-account-balance-on-cot'],
                 ][$this->step];
             },

--- a/src/AppBundle/Form/Report/BankAccountType.php
+++ b/src/AppBundle/Form/Report/BankAccountType.php
@@ -96,15 +96,20 @@ class BankAccountType extends AbstractType
         $resolver->setDefaults([
             'translation_domain' => 'report-bank-accounts',
             'validation_groups'  => function (FormInterface $form) {
-                $requiresBankNameAndSortCode = $form->getData()->requiresBankNameAndSortCode();
+
+                $step2Options = ['bank-account-number', 'bank-account-is-joint'];
+                if ($form->getData()->requiresSortCode()) {
+                    $step2Options[] = 'bank-account-sortcode';
+                }
+                if ($form->getData()->requiresBankName()) {
+                    $step2Options[] = 'bank-account-name';
+                }
 
                 return [
                     1 => ['bank-account-type'],
-                    2 => $requiresBankNameAndSortCode ?
-                        ['bank-account-name', 'bank-account-sortcode', 'bank-account-number', 'bank-account-is-joint']
-                        : ['bank-account-number', 'bank-account-is-joint'],
+                    2 => $step2Options,
                     3 => ['bank-account-opening-balance'],
-                    4 => 'bank-account-is-closed',
+                    4 => 'bank-account-is-closed'
                 ][$this->step];
             },
         ]);

--- a/src/AppBundle/Resources/views/Odr/BankAccount/_list.html.twig
+++ b/src/AppBundle/Resources/views/Odr/BankAccount/_list.html.twig
@@ -28,12 +28,12 @@
     {% for account in odr.bankAccounts %}
         <tr class="behat-region-account-{{ account.accountNumber | behat_namify }}">
             <td>
-                {% if account.requiresBankNameAndSortCode %}
+                {% if account.requiresBankName %}
                     {{ account.bank }}<br/>
                 {% endif %}
                 <p class="font-xsmall flush--ends">
                     {{ account.accountTypeText }}<br/>
-                    {% if account.requiresBankNameAndSortCode %}
+                    {% if account.requiresSortCode %}
                         Sort code: {{ account.sortCode }}<br/>
                     {% endif %}
                     Account number: ****{{ account.accountNumber }}<br/>

--- a/src/AppBundle/Resources/views/Odr/BankAccount/step.html.twig
+++ b/src/AppBundle/Resources/views/Odr/BankAccount/step.html.twig
@@ -34,7 +34,7 @@
 
     {% if step == 2 %}
 
-        {% if account.requiresBankNameAndSortCode %}
+        {% if account.requiresBankName %}
             {{ form_input(form.bank, 'form.bank') }}
         {% else %}
             {% do form.bank.setRendered %}
@@ -44,7 +44,7 @@
             'inputClass' : 'account-number'
         }) }}
 
-        {% if account.requiresBankNameAndSortCode %}
+        {% if account.requiresSortCode %}
             {{ form_sort_code(form.sortCode, 'form.sortCode') }}
         {% else %}
             {% do form.sortCode.setRendered %}

--- a/src/AppBundle/Resources/views/Odr/Formatted/_accounts.html.twig
+++ b/src/AppBundle/Resources/views/Odr/Formatted/_accounts.html.twig
@@ -21,7 +21,7 @@
                                     {{ account.bank }} {{ account.accountTypeText }}
                                 </div>
                                 <div class="account-number">****{{ account.accountNumber }}
-                                    {% if account.requiresBankNameAndSortCode and account.sortCode %}
+                                    {% if account.requiresSortCode and account.sortCode %}
                                         , {{ account.sortCode | split('', 2) | join('-') }}
                                     {% endif %}
                                 </div>

--- a/src/AppBundle/Resources/views/Report/BankAccount/_list.html.twig
+++ b/src/AppBundle/Resources/views/Report/BankAccount/_list.html.twig
@@ -29,12 +29,12 @@
     {% for account in report.bankAccounts %}
         <tr class="behat-region-account-{{ account.accountNumber | behat_namify }}">
             <td>
-                {% if account.requiresBankNameAndSortCode %}
+                {% if account.requiresBankName %}
                     {{ account.bank }}<br/>
                 {% endif %}
                 <p class="font-xsmall flush--ends">
                     {{ account.accountTypeText }}<br/>
-                    {% if account.requiresBankNameAndSortCode %}
+                    {% if account.requiresSortCode %}
                         Sort code: {{ account.sortCode }}<br/>
                     {% endif %}
                     Account number: ****{{ account.accountNumber }}<br/>

--- a/src/AppBundle/Resources/views/Report/BankAccount/step.html.twig
+++ b/src/AppBundle/Resources/views/Report/BankAccount/step.html.twig
@@ -34,17 +34,18 @@
 
     {% if step == 2 %}
 
-        {% if account.requiresBankNameAndSortCode %}
+        {% if account.requiresBankName %}
             {{ form_input(form.bank, 'form.bank') }}
         {% else %}
             {% do form.bank.setRendered %}
         {% endif %}
 
+
         {{ form_input(form.accountNumber, 'form.accountNumber', {
             'inputClass' : 'account-number'
         }) }}
 
-        {% if account.requiresBankNameAndSortCode %}
+        {% if account.requiresSortCode %}
             {{ form_sort_code(form.sortCode, 'form.sortCode') }}
         {% else %}
             {% do form.sortCode.setRendered %}

--- a/src/AppBundle/Resources/views/Report/Formatted/Accounts/_summary.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/Accounts/_summary.html.twig
@@ -20,7 +20,7 @@
                             {{ account.bank }} {{ account.accountTypeText }}
                         </div>
                         <div class="account-number">****{{ account.accountNumber }}
-                            {% if account.requiresBankNameAndSortCode and account.sortCode %}
+                            {% if account.requiresSortCode and account.sortCode %}
                                , {{ account.sortCode | split('', 2) | join('-') }}
                             {% endif %}
                             {% if account.isJointAccount =='yes' %}

--- a/src/AppBundle/Resources/views/Report/MoneyTransfer/_list.html.twig
+++ b/src/AppBundle/Resources/views/Report/MoneyTransfer/_list.html.twig
@@ -57,7 +57,7 @@
                 <tr class="behat-region-transfer-{{ transfer.accountFrom.accountNumber }}-{{ transfer.accountTo.accountNumber }}-{{ transfer.amount | behat_namify }}">
                     <td class="width-quarter">
                         {% set account = transfer.accountFrom %}
-                        {% if account.requiresBankNameAndSortCode %}
+                        {% if account.requiresBankName %}
                             {{ account.bank }}<br/>
                         {% endif %}
                         <p class="font-xsmall flush--ends">
@@ -69,7 +69,7 @@
                     </td>
                     <td class="width-quarter">
                         {% set account = transfer.accountTo %}
-                        {% if account.requiresBankNameAndSortCode %}
+                        {% if account.requiresBankName %}
                             {{ account.bank }}<br/>
                         {% endif %}
                         <p class="font-xsmall flush--ends">

--- a/tests/behat/features/pa/05-edit-report-sections.feature
+++ b/tests/behat/features/pa/05-edit-report-sections.feature
@@ -130,7 +130,7 @@ Feature: PA user edits report sections
     And the step with the following values CAN be submitted:
       | yes_no_hasDebts_1 | no |
 
-  Scenario: PA add account
+  Scenario: PA add current account
     Given I am logged in as "behat-pa1@publicguardian.gsi.gov.uk" with password "Abcd1234"
     And I click on "pa-report-open" in the "client-1000014" region
     And I click on "edit-bank_accounts, start"
@@ -138,12 +138,59 @@ Feature: PA user edits report sections
     And the step with the following values CAN be submitted:
       | account_accountType_0 | current |
     # add account n.1 (current)
+    And I should see an "input#account_bank" element
+    And I should see an "input#account_sortCode_sort_code_part_1" element
+    And I should see an "input#account_sortCode_sort_code_part_2" element
+    And I should see an "input#account_sortCode_sort_code_part_3" element
     And the step with the following values CAN be submitted:
       | account_bank                      | HSBC - main account |
       | account_accountNumber             | 01ca                |
       | account_sortCode_sort_code_part_1 | 11                  |
       | account_sortCode_sort_code_part_2 | 22                  |
       | account_sortCode_sort_code_part_3 | 33                  |
+      | account_isJointAccount_1          | no                  |
+    And the step with the following values CAN be submitted:
+      | account_openingBalance | 100.40 |
+      | account_closingBalance | 100.40 |
+    # add another: no
+    And I choose "no" when asked for adding another record
+
+  Scenario: PA add postoffice account (no sort code, no bank name)
+    Given I am logged in as "behat-pa1@publicguardian.gsi.gov.uk" with password "Abcd1234"
+    And I click on "pa-report-open" in the "client-1000014" region
+    And I click on "edit-bank_accounts, add"
+    # step 1
+    And the step with the following values CAN be submitted:
+      | account_accountType_0 | postoffice |
+    # add account n.1 (current)
+    And the step with the following values CAN be submitted:
+      | account_accountNumber             | 01ca                |
+      | account_isJointAccount_1          | no                  |
+    And I should not see an "input#account_bank" element
+    And I should not see an "input#account_sortCode_sort_code_part_1" element
+    And I should not see an "input#account_sortCode_sort_code_part_2" element
+    And I should not see an "input#account_sortCode_sort_code_part_3" element
+    And the step with the following values CAN be submitted:
+      | account_openingBalance | 100.40 |
+      | account_closingBalance | 100.40 |
+    # add another: no
+    And I choose "no" when asked for adding another record
+    
+  Scenario: PA add no sortcode account (still requires bank name)
+    Given I am logged in as "behat-pa1@publicguardian.gsi.gov.uk" with password "Abcd1234"
+    And I click on "pa-report-open" in the "client-1000014" region
+    And I click on "edit-bank_accounts, add"
+    # step 1
+    And the step with the following values CAN be submitted:
+      | account_accountType_0 | other_no_sortcode |
+    # add account n.1 (current)
+    And I should see an "input#account_bank" element
+    And I should not see an "input#account_sortCode_sort_code_part_1" element
+    And I should not see an "input#account_sortCode_sort_code_part_2" element
+    And I should not see an "input#account_sortCode_sort_code_part_3" element
+    And the step with the following values CAN be submitted:
+      | account_bank                      | Bank of Jack        |
+      | account_accountNumber             | 01ca                |
       | account_isJointAccount_1          | no                  |
     And the step with the following values CAN be submitted:
       | account_openingBalance | 100.40 |


### PR DESCRIPTION
Co-dependency on the API PR https://github.com/ministryofjustice/opg-digi-deps-api/pull/341

There was an assumption that bank account types which didn't require a sort code ALSO didn't require a bank account name, but this is incorrect: the type 'other_no_sortcode' requires no sort code but still requires a bank name

SO work done to turn the requiresBankNameAndSortCode() function into separate requiresBankName() and requiresSortCode() functions