### PR TITLE
DDPB-1764: reduce docker build times

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,8 @@ COPY composer.lock /app/
 WORKDIR /app
 USER app
 ENV  HOME /app
-RUN  composer install --prefer-source --no-interaction --no-scripts
+RUN  composer global require hirak/prestissimo
+RUN  composer install --prefer-dist --no-interaction --no-scripts
 RUN  composer dump-autoload --optimize
 COPY package.json /app/
 RUN  npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN  apt-add-repository ppa:brightbox/ruby-ng && \
         apt-get clean && apt-get autoremove && \
         rm -rf /var/lib/cache/* /var/lib/log/* /tmp/* /var/tmp/*
 
+USER root
 #upgrade npm
-RUN  npm install npm@4.6.1 -g
+RUN  npm install npm@4.6.1 -g && npm -g set progress=false
 RUN  cd /tmp && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
 
 RUN  npm install --global gulp


### PR DESCRIPTION
This PR aims to shrink the ```docker build .``` times to negative values.
Not there yet, but locally I achieved some good results:

my baseline
On jenkins, the 01_Build_Docker_Images job averages around 30minutes

locally:
```
time docker build --no-cache .

real    12m6.638s
user    0m1.421s
sys     0m0.133s
```
with these changes:

```
time docker build --no-cache .

real    4m34.245s
user    0m1.459s
sys     0m0.196s
```

Jenkins jobs:

(24min) with only the changes from this PR:
https://jenkins.service.opg.digital/job/Digi-Deps/job/01_Build_Docker_Images/654/console

(13min) with these changes + https://github.com/ministryofjustice/opg-digi-deps-docker/pull/60
https://jenkins.service.opg.digital/job/Digi-Deps/job/01_Build_Docker_Images/652/console

