### PR TITLE
DDPB-1764: split Dockerfile and add a nightly Dockerfile.base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,17 @@
 FROM registry.service.opg.digital/opguk/digi-deps-frontend-base:nightly
 
+# build app dependencies
+COPY composer.json /app/
+COPY composer.lock /app/
+WORKDIR /app
+USER app
+ENV  HOME /app
+RUN  composer global require hirak/prestissimo
+RUN  composer install --prefer-dist --no-interaction --no-scripts
+RUN  composer dump-autoload --optimize
+COPY package.json /app/
+RUN  npm install
+
 # install remaining parts of app
 ADD  . /app
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
 FROM registry.service.opg.digital/opguk/digi-deps-frontend-base:nightly
 
-# build app dependencies
-COPY composer.json /app/
-COPY composer.lock /app/
 WORKDIR /app
 USER app
 ENV  HOME /app
-RUN  composer global require hirak/prestissimo
 RUN  composer install --prefer-dist --no-interaction --no-scripts
 RUN  composer dump-autoload --optimize
 COPY package.json /app/
+RUN  npm -g set progress=false
 RUN  npm install
 
 # install remaining parts of app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,4 @@
-FROM registry.service.opg.digital/opguk/php-fpm
-
-# adds nodejs pkg repository
-RUN  curl --silent --location https://deb.nodesource.com/setup_8.x | bash -
-
-RUN  apt-add-repository ppa:brightbox/ruby-ng && \
-        apt-get update && \
-        apt-get install -y \
-        php-pear php5-curl php5-memcached php5-redis \
-        dos2unix postgresql-client \
-        nodejs ruby2.4 ruby2.4-dev && \
-        apt-get clean && apt-get autoremove && \
-        rm -rf /var/lib/cache/* /var/lib/log/* /tmp/* /var/tmp/*
-
-USER root
-#upgrade npm
-RUN  npm install npm@4.6.1 -g && npm -g set progress=false
-RUN  cd /tmp && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
-
-RUN  npm install --global gulp
-RUN  gem install --no-ri --no-rdoc sass -v 3.4.25
-RUN  gem install --no-ri --no-rdoc scss_lint -v 0.54.0
-
-# build app dependencies
-COPY composer.json /app/
-COPY composer.lock /app/
-WORKDIR /app
-USER app
-ENV  HOME /app
-RUN  composer global require hirak/prestissimo
-RUN  composer install --prefer-dist --no-interaction --no-scripts
-RUN  composer dump-autoload --optimize
-COPY package.json /app/
-RUN  npm install
+FROM registry.service.opg.digital/opguk/digi-deps-frontend-base:nightly
 
 # install remaining parts of app
 ADD  . /app

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,35 @@
+FROM registry.service.opg.digital/opguk/php-fpm
+
+# adds nodejs pkg repository
+RUN  curl --silent --location https://deb.nodesource.com/setup_8.x | bash -
+
+RUN  apt-add-repository ppa:brightbox/ruby-ng && \
+        apt-get update && \
+        apt-get install -y \
+        php-pear php5-curl php5-memcached php5-redis \
+        dos2unix postgresql-client \
+        nodejs ruby2.4 ruby2.4-dev && \
+        apt-get clean && apt-get autoremove && \
+        rm -rf /var/lib/cache/* /var/lib/log/* /tmp/* /var/tmp/*
+
+USER root
+#upgrade npm
+RUN  npm install npm@4.6.1 -g && npm -g set progress=false
+RUN  cd /tmp && curl -sS https://getcomposer.org/installer | php && mv composer.phar /usr/local/bin/composer
+
+RUN  npm install --global gulp
+RUN  gem install --no-ri --no-rdoc sass -v 3.4.25
+RUN  gem install --no-ri --no-rdoc scss_lint -v 0.54.0
+
+# build app dependencies
+COPY composer.json /app/
+COPY composer.lock /app/
+WORKDIR /app
+USER app
+ENV  HOME /app
+RUN  composer global require hirak/prestissimo
+RUN  composer install --prefer-dist --no-interaction --no-scripts
+RUN  composer dump-autoload --optimize
+COPY package.json /app/
+RUN  npm install
+

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -28,8 +28,3 @@ WORKDIR /app
 USER app
 ENV  HOME /app
 RUN  composer global require hirak/prestissimo
-RUN  composer install --prefer-dist --no-interaction --no-scripts
-RUN  composer dump-autoload --optimize
-COPY package.json /app/
-RUN  npm install
-


### PR DESCRIPTION
See: ministryofjustice/opg-digi-deps-docker#61

This PR splits the Dockerfile into a nightly build using a Dockerfile.base and the normal build which will consume a FROM: nnnnn-base:nightly.