### PR TITLE
DDPB-2405 Fix money out in financial summary preview

### DIFF
--- a/src/AppBundle/Resources/views/Report/Formatted/Accounts/_final_summary.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/Accounts/_final_summary.html.twig
@@ -17,11 +17,7 @@
             <tr>
                 <td>Money out:</td>
                 <td class="grey numeric">
-                    {% if report.hasSection('profDeputyCosts') %}
-                        &pound;{{ (report.moneyOutTotal + report.profDeputyTotalCosts) | money_format}}
-                    {% else %}
-                        &pound;{{ report.moneyOutTotal | money_format}}
-                    {% endif %}
+                    &pound;{{ report.moneyOutTotal | money_format}}
                 </td>
             </tr>
             {% if not app.user.isDeputyProf() %}


### PR DESCRIPTION
The financial summary is counting deputy costs twice (as costs
and in money out) - this is fixed here so money out is separate.