### PR TITLE
DDPB-2405 Don't show empty translation for howcharged

### DIFF
--- a/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
@@ -7,8 +7,12 @@
         <div class="box" data-prof-deputy-costs-how-charged>
             <h3 class="label question bold">{{ 'howCharged.form.profDeputyCostsEstimateHowCharged.label'|trans }}</h3>
             <div class="value">
+            {% if report.profDeputyCostsEstimateHowCharged %}
                 {{ ('howCharged.form.options.' ~
                 report.profDeputyCostsEstimateHowCharged) | trans }}
+            {% else %}
+                &nbsp;
+            {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
For deputy estimates when not filled in preview was showing an
empty translation key. This is now only shown if there is an
option selected for how charge.