### PR TITLE
DDPB-2442: Downloads Report Submission .dat files in 24 hour format

### DIFF
--- a/src/AppBundle/Controller/Admin/StatsController.php
+++ b/src/AppBundle/Controller/Admin/StatsController.php
@@ -59,7 +59,7 @@ class StatsController extends AbstractController
         $response = new Response($csvContent);
         $response->headers->set('Content-Type', 'application/octet-stream');
 
-        $attachmentName = sprintf('cwsdigidepsopg00001%s.dat', date('Ymdhi'));
+        $attachmentName = sprintf('cwsdigidepsopg00001%s.dat', date('YmdHi'));
         $response->headers->set('Content-Disposition', 'attachment; filename="' . $attachmentName . '"');
 
         $response->sendHeaders();


### PR DESCRIPTION
Something I noticed whilst fixing DDPB-2442. There is potential for a filename clash due to 12 hour format, so worth a quick fix whilst fixing 2442.