### PR TITLE
DDPB-2459 Request cost certificate from professional deputies

### DIFF
--- a/src/AppBundle/Resources/translations/report-documents.en.yml
+++ b/src/AppBundle/Resources/translations/report-documents.en.yml
@@ -49,6 +49,8 @@ startPage:
   notice: |
     You do not need to attach a copy of this report. When you submit your report it will be
     sent to OPG automatically.
+  deputyProfNotice: |
+    Send your final cost certificate for the previous reporting period.
   startButton: Start
 
 stepPage:

--- a/src/AppBundle/Resources/views/Report/Document/start.html.twig
+++ b/src/AppBundle/Resources/views/Report/Document/start.html.twig
@@ -16,7 +16,9 @@
 
     <p class="text">{{ 'startPage.pageSectionDescription1' | trans(transOptions) }}</p>
 
-    {% if not app.user.isDeputyProf() %}
+    {% if app.user.isDeputyProf() %}
+        {{ macros.notification('info', 'startPage.deputyProfNotice' | trans) }}
+    {% else %}
         {{ macros.notification('info', 'startPage.notice' | trans) }}
     {% endif %}
 


### PR DESCRIPTION
Changes the warning message on the supported documents page for professional deputies, prompting them to upload a cost certificate.