### PR TITLE
DDPB-2468 Remove Agreed costs option from 105

### DIFF
--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -28,14 +28,6 @@ trait ReportProfDeputyCostsTrait
     private $profDeputyCostsHowChargedAssessed;
 
     /**
-     * @var boolean
-     *
-     * @JMS\Type("boolean")
-     * @JMS\Groups({"deputyCostsHowCharged"})
-     */
-    private $profDeputyCostsHowChargedAgreed;
-
-    /**
      * @var string yes/no
      *
      * @JMS\Type("string")
@@ -127,8 +119,7 @@ trait ReportProfDeputyCostsTrait
     public function hasProfDeputyCostsHowChargedFixedOnly()
     {
         return $this->profDeputyCostsHowChargedFixed
-            && !$this->profDeputyCostsHowChargedAssessed
-            && !$this->profDeputyCostsHowChargedAgreed;
+            && !$this->profDeputyCostsHowChargedAssessed;
     }
 
     /**
@@ -190,30 +181,12 @@ trait ReportProfDeputyCostsTrait
     }
 
     /**
-     * @return boolean
-     */
-    public function getProfDeputyCostsHowChargedAgreed()
-    {
-        return $this->profDeputyCostsHowChargedAgreed;
-    }
-
-    /**
-     * @param string $profDeputyCostsHowChargedAgreed
-     */
-    public function setProfDeputyCostsHowChargedAgreed($profDeputyCostsHowChargedAgreed)
-    {
-        $this->profDeputyCostsHowChargedAgreed = $profDeputyCostsHowChargedAgreed;
-        return $this;
-    }
-
-    /**
      * @param ExecutionContextInterface $context
      */
     public function profCostsHowChangedAtLeastOne(ExecutionContextInterface $context)
     {
         if (!$this->profDeputyCostsHowChargedFixed
             && !$this->profDeputyCostsHowChargedAssessed
-            && ! $this->profDeputyCostsHowChargedAgreed
         ) {
             $context->buildViolation('profDeputyHowChanged.atLeastOne')
                 ->atPath('profDeputyCostsHowChargedFixed')

--- a/src/AppBundle/Form/Report/ProfDeputyCostHowType.php
+++ b/src/AppBundle/Form/Report/ProfDeputyCostHowType.php
@@ -14,7 +14,6 @@ class ProfDeputyCostHowType extends AbstractType
         $builder
             ->add('profDeputyCostsHowChargedFixed', FormTypes\CheckboxType::class)
             ->add('profDeputyCostsHowChargedAssessed', FormTypes\CheckboxType::class)
-            ->add('profDeputyCostsHowChargedAgreed', FormTypes\CheckboxType::class)
             ->add('save', FormTypes\SubmitType::class, ['label' => 'save.label']);
     }
 

--- a/src/AppBundle/Resources/translations/report-prof-deputy-costs.en.yml
+++ b/src/AppBundle/Resources/translations/report-prof-deputy-costs.en.yml
@@ -21,7 +21,6 @@ howCharged:
     profDeputyCostsHow.hint: "Select all that apply"
     profDeputyCostsHowChargedFixed.label: "Fixed costs"
     profDeputyCostsHowChargedAssessed.label: "Assessed costs"
-    profDeputyCostsHowChargedAgreed.label: "Agreed"
 
 previousReceivedExists:
   htmlTitle: "Deputy report - Deputy costs | GOV.UK"

--- a/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs.html.twig
@@ -13,8 +13,6 @@
                     <td class="label">{{ 'howCharged.form.profDeputyCostsHowChargedFixed.label' | trans(transOptions) }}</td>
                     <td class="value checkbox">{% if report.profDeputyCostsHowChargedAssessed == true %}X{% else %}&nbsp;{% endif %}</td>
                     <td class="label">{{ 'howCharged.form.profDeputyCostsHowChargedAssessed.label' | trans(transOptions) }}</td>
-                    <td class="value checkbox">{% if report.profDeputyCostsHowChargedAgreed == true %}X{% else %}&nbsp;{% endif %}</td>
-                    <td class="label">{{ 'howCharged.form.profDeputyCostsHowChargedAgreed.label' | trans(transOptions) }}</td>
                 </tr>
             </table>
         </div>
@@ -60,7 +58,7 @@
         {% if
             report.hasProfDeputyCostsHowChargedFixedOnly or
             not report.profDeputyCostsHasInterim or
-            (not report.profDeputyCostsHowChargedFixed and not report.profDeputyCostsHowChargedAssessed and not report.profDeputyCostsHowChargedAgreed)
+            (not report.profDeputyCostsHowChargedFixed and not report.profDeputyCostsHowChargedAssessed)
         %}
             <div class="box" data-prof-deputy-costs-fixed-cost>
                 <h3 class="label question bold">{{ 'fixedCost.form.profDeputyFixedCost.label' | trans(transOptions) }}</h3>

--- a/src/AppBundle/Resources/views/Report/ProfDeputyCosts/_how_charged_answers.html.twig
+++ b/src/AppBundle/Resources/views/Report/ProfDeputyCosts/_how_charged_answers.html.twig
@@ -13,7 +13,6 @@
         <td>
             {{ report.profDeputyCostsHowChargedFixed ? 'Fixed<br>' : '' | raw }}
             {{ report.profDeputyCostsHowChargedAssessed ? 'Assessed<br>' : '' | raw }}
-            {{ report.profDeputyCostsHowChargedAgreed  ? 'Agreed<br>' : '' | raw}}
         </td>
         {% if not hideEditLink  %}
             <td class="change-answer">

--- a/src/AppBundle/Resources/views/Report/ProfDeputyCosts/howCharged.html.twig
+++ b/src/AppBundle/Resources/views/Report/ProfDeputyCosts/howCharged.html.twig
@@ -41,11 +41,6 @@
             'useFormGroup': false,
             'formGroupClass': 'form-group-compound',
         }) }}
-
-        {{ form_checkbox(form.profDeputyCostsHowChargedAgreed, page ~ '.form.profDeputyCostsHowChargedAgreed', {
-            'useFormGroup': false,
-            'formGroupClass': 'form-group-compound',
-        }) }}
     </div>
 
     {{ macros.saveAndContinueButton(form.save) }}

--- a/tests/behat/features/prof/03-report/05-deputy-costs.feature
+++ b/tests/behat/features/prof/03-report/05-deputy-costs.feature
@@ -36,7 +36,6 @@ Feature: PROF deputy costs
     Then the step with the following values CAN be submitted:
       | deputy_costs_profDeputyCostsHowChargedFixed    | 1 |
       | deputy_costs_profDeputyCostsHowChargedAssessed | 1 |
-      | deputy_costs_profDeputyCostsHowChargedAgreed   | 1 |
     # previous = no
     And the step with the following values CAN be submitted:
       | yes_no_profDeputyCostsHasPrevious_1 | no |
@@ -163,7 +162,6 @@ Feature: PROF deputy costs
     Then the step with the following values CAN be submitted:
       | deputy_costs_profDeputyCostsHowChargedFixed    | 1 |
       | deputy_costs_profDeputyCostsHowChargedAssessed | 1 |
-      | deputy_costs_profDeputyCostsHowChargedAgreed   | 1 |
     # previous=yes
     And the step with the following values CAN be submitted:
       | yes_no_profDeputyCostsHasPrevious_1 | yes |

--- a/tests/behat/features/prof/03-report/05-deputy-costs.feature
+++ b/tests/behat/features/prof/03-report/05-deputy-costs.feature
@@ -54,7 +54,6 @@ Feature: PROF deputy costs
     And each text should be present in the corresponding region:
       | Fixed    | how-changed       |
       | Assessed | how-changed       |
-      | Agreed   | how-changed       |
       | No       | has-previous      |
       | No       | has-interim       |
       | 1,000.00 | fixed-cost-amount |
@@ -207,7 +206,6 @@ Feature: PROF deputy costs
     And each text should be present in the corresponding region:
       | Fixed                                | how-changed             |
       | Assessed                             | how-changed             |
-      | Agreed                               | how-changed             |
       | Yes                                  | has-previous            |
       | Received for 01/01/2015 - 01/01/2016 | prev-cost-1             |
       | £100                                 | prev-cost-1             |

--- a/tests/phpunit/Resources/views/Report/FormattedTest.php
+++ b/tests/phpunit/Resources/views/Report/FormattedTest.php
@@ -420,8 +420,7 @@ class FormattedTest extends WebTestCase
         $this
             ->report
             ->setProfDeputyCostsHowChargedFixed(null)
-            ->setProfDeputyCostsHowChargedAssessed(null)
-            ->setProfDeputyCostsHowChargedAgreed(null);
+            ->setProfDeputyCostsHowChargedAssessed(null);
     }
 
     /**
@@ -432,8 +431,7 @@ class FormattedTest extends WebTestCase
         $this
             ->report
             ->setProfDeputyCostsHowChargedFixed(true)
-            ->setProfDeputyCostsHowChargedAssessed(false)
-            ->setProfDeputyCostsHowChargedAgreed(false);
+            ->setProfDeputyCostsHowChargedAssessed(false);
     }
 
     private function ensureDeputyCostsWithNonFixedAndInterimEqualTo($interim)
@@ -454,7 +452,6 @@ class FormattedTest extends WebTestCase
             ->report
             ->setProfDeputyCostsHowChargedFixed(true)
             ->setProfDeputyCostsHowChargedAssessed(true)
-            ->setProfDeputyCostsHowChargedAgreed(false)
             ->setProfDeputyCostsHasInterim(null);
     }
 


### PR DESCRIPTION
This removes all references to "Agreed costs" in the deputy costs section of the report. It removes the option from forms, output and summary, and also from any related tests.

This should be merged before [the API/DB changes](https://github.com/ministryofjustice/opg-digi-deps-api/pull/509) to ensure the client isn't making reference to deleted fields.