### PR TITLE
DDPB-2491 Allow wkhtmltopdf host address to be configured

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -62,3 +62,4 @@ parameters:
         secret: 'YOUR_SECRET_ACCESS_KEY'
     file_scanner_url: https://file-scanner-api:8443
     file_scanner_sslverify: false
+    wkhtmltopdf_address: "http://wkhtmltopdf:80"

--- a/app/config/services.yml
+++ b/app/config/services.yml
@@ -23,7 +23,7 @@ services:
 
     wkhtmltopdf:
         class: AppBundle\Service\WkHtmlToPdfGenerator
-        arguments: [ "http://wkhtmltopdf:80", 30]
+        arguments: [ "%wkhtmltopdf_address%", 30]
 
     step_redirector:
       class: AppBundle\Service\StepRedirector

--- a/docker/confd/conf.d/parameters.hml.toml
+++ b/docker/confd/conf.d/parameters.hml.toml
@@ -18,5 +18,6 @@ keys = [
     "/frontend/s3/bucketname",
     "/frontend/s3/fakes3",
     "/frontend/filescanner/url",
-    "/frontend/filescanner/sslverify"
+    "/frontend/filescanner/sslverify",
+    "/wkhtmltopdf/address"
  ]

--- a/docker/confd/templates/parameters.yml.tmpl
+++ b/docker/confd/templates/parameters.yml.tmpl
@@ -33,6 +33,7 @@ parameters:
     smtp_default_password: {{ getv "/frontend/smtp/default/password" }}
     smtp_secure_hostname: {{ getv "/frontend/smtp/secure/hostname" }}
     smtp_secure_port: {{ getv "/frontend/smtp/secure/port" }}
+    wkhtmltopdf_address: {{ getv "wkhtmltopdf/address" }}
     s3_bucket_name: {{ if exists "/frontend/s3/bucketname" }}{{ getv "/frontend/s3/bucketname" }}{{ else }}not_set{{ end }}
     s3_client_params:
       version: 'latest'

--- a/docker/confd/templates/parameters.yml.tmpl
+++ b/docker/confd/templates/parameters.yml.tmpl
@@ -33,7 +33,7 @@ parameters:
     smtp_default_password: {{ getv "/frontend/smtp/default/password" }}
     smtp_secure_hostname: {{ getv "/frontend/smtp/secure/hostname" }}
     smtp_secure_port: {{ getv "/frontend/smtp/secure/port" }}
-    wkhtmltopdf_address: {{ getv "wkhtmltopdf/address" }}
+    wkhtmltopdf_address: {{ getv "/wkhtmltopdf/address" }}
     s3_bucket_name: {{ if exists "/frontend/s3/bucketname" }}{{ getv "/frontend/s3/bucketname" }}{{ else }}not_set{{ end }}
     s3_client_params:
       version: 'latest'


### PR DESCRIPTION
Currently the html to pdf container address is hardcoded. This change uses an address passed in from an env var, and allows us to isolate the containers and change them independently.