### PR TITLE
Feature/DDPB-2458 - Add general management figure to summary, Preview page and PDF

### DIFF
--- a/src/AppBundle/Controller/Report/ProfDeputyCostsEstimateController.php
+++ b/src/AppBundle/Controller/Report/ProfDeputyCostsEstimateController.php
@@ -22,7 +22,8 @@ class ProfDeputyCostsEstimateController extends AbstractController
         'status',
         'prof-deputy-costs-estimate-how-charged',
         'prof-deputy-estimate-costs',
-        'prof-deputy-costs-estimate-more-info'
+        'prof-deputy-costs-estimate-more-info',
+        'prof-deputy-estimate-management-costs'
     ];
 
     /**

--- a/src/AppBundle/Controller/Report/ReportController.php
+++ b/src/AppBundle/Controller/Report/ReportController.php
@@ -40,6 +40,7 @@ class ReportController extends AbstractController
         'prof-deputy-costs-estimate-how-charged',
         'prof-deputy-estimate-costs',
         'prof-deputy-costs-estimate-more-info',
+        'prof-deputy-estimate-management-costs',
         'action',
         'action-more-info',
         'asset',

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsEstimateTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsEstimateTrait.php
@@ -218,7 +218,6 @@ trait ReportProfDeputyCostsEstimateTrait
             $submittedCosts[$defaultEstimateCost['typeId']]['amount'] = !empty($submittedCost) ? $submittedCost->getAmount() : null;
             $submittedCosts[$defaultEstimateCost['typeId']]['hasMoreDetails'] = $defaultEstimateCost['hasMoreDetails'];
             $submittedCosts[$defaultEstimateCost['typeId']]['moreDetails'] = !empty($submittedCost) ? $submittedCost->getMoreDetails() : '';
-
         }
 
         return $submittedCosts;

--- a/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
@@ -18,63 +18,79 @@
     </div>
 
     {% if report.profDeputyCostsEstimateHowCharged != 'fixed' %}
-    <div class="dont-break">
-        <div class="box" data-prof-deputy-costs-breakdown>
-            <h3 class="label question bold">{{ 'breakdown.pageSectionDescription'|trans(transOptions) }}</h3>
-            <table class="labelvalue money">
-            {% for costRow in report.profDeputyEstimateCosts %}
-                <tr>
-                    <td class="label">
-                        {{ ('breakdown.form.entries.' ~ costRow.
-                        profDeputyEstimateCostTypeId ~ '.label') | trans }}
-                    </td>
-                    <td class="value total width-fifth">
-                        £{{ costRow.amount | money_format }}
-                    </td>
-                </tr>
-                {% if costRow.hasMoreDetails and costRow.moreDetails %}
-                <tr>
-                    <td class="label" data-prof-deputy-cost-estimtaes-breakdown-more-details>
-                        {{ ('breakdown.form.entries.' ~ costRow.
-                        profDeputyEstimateCostTypeId ~ 
-                        '.moreInformationLabelSummary') | trans }}</td>
-                    <td class="value total width-half">
-                        {{ costRow.moreDetails | nl2br }}
-                    </td>
-                </tr>
+        <div class="dont-break">
+            <div class="box" data-prof-deputy-management-cost>
+                <h3 class="label question bold">{{ 'breakdown.form.profDeputyCostsEstimateManagementCost.sectionDescription'|trans(transOptions) }}</h3>
+                <table class="labelvalue money">
+                    <tr>
+                        <td class="label">
+                            {{ 'breakdown.form.profDeputyCostsEstimateManagementCost.label' | trans }}
+                        </td>
+                        <td class="value total width-half">
+                            £{{ (report.getProfDeputyManagementCostAmount) | money_format }}
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </div>
+
+        <div class="dont-break">
+            <div class="box" data-prof-deputy-costs-breakdown>
+                <h3 class="label question bold">{{ 'breakdown.pageSectionDescription'|trans(transOptions) }}</h3>
+                <table class="labelvalue money">
+                {% for costRow in report.profDeputyEstimateCosts %}
+                    <tr>
+                        <td class="label">
+                            {{ ('breakdown.form.entries.' ~ costRow.
+                            profDeputyEstimateCostTypeId ~ '.label') | trans }}
+                        </td>
+                        <td class="value total width-fifth">
+                            £{{ costRow.amount | money_format }}
+                        </td>
+                    </tr>
+                    {% if costRow.hasMoreDetails and costRow.moreDetails %}
+                        <tr>
+                            <td class="label" data-prof-deputy-cost-estimtaes-breakdown-more-details>
+                                {{ ('breakdown.form.entries.' ~ costRow.
+                                profDeputyEstimateCostTypeId ~
+                                '.moreInformationLabelSummary') | trans }}</td>
+                            <td class="value total width-half">
+                                {{ costRow.moreDetails | nl2br }}
+                            </td>
+                        </tr>
+                    {% endif %}
+
+                {% endfor %}
+                </table>
+            </div>
+        </div>
+
+        <div class="dont-break">
+            <div class="box" data-prof-deputy-costs-total>
+                <h3 class="label question bold">{{ ('totalEstimatedCosts') | trans }}</h3>
+                <div class="value">
+                    £{{ report.profDeputyEstimateCostsTotal | money_format }}
+                </div>
+            </div>
+        </div>
+
+        <div class="dont-break">
+            <div class="box" data-prof-deputy-costs-estimate-has-more-info>
+                <h3 class="label question bold">{{ 'moreInfo.form.profDeputyCostsEstimateHasMoreInfoSummary.yesno'|trans }}</h3>
+                <table class="checkboxes labelvalue inline">
+                    <tr>
+                        <td class="value checkbox">{% if report.profDeputyCostsEstimateHasMoreInfo == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="label">{{ 'yes' | trans({}, 'common') }}</td>
+                        <td class="value checkbox">{% if report.profDeputyCostsEstimateHasMoreInfo == 'no' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="label">{{ 'no' | trans({}, 'common') }}</td>
+                    </tr>
+                </table>
+                {% if report.profDeputyCostsEstimateHasMoreInfo == 'yes' %}
+                    <div class="labelvalue push-half--top">
+                        <div class="value">{{ report.profDeputyCostsEstimateMoreInfoDetails | capitalize | trans }}</div>
+                    </div>
                 {% endif %}
-
-            {% endfor %}
-            </table>
-        </div>
-    </div>
-
-    <div class="dont-break">
-        <div class="box" data-prof-deputy-costs-total>
-            <h3 class="label question bold">{{ ('totalEstimatedCosts') | trans }}</h3>
-            <div class="value">
-                £{{ report.profDeputyEstimateCostsTotal | money_format }}
             </div>
         </div>
-    </div>    
-
-    <div class="dont-break">
-        <div class="box" data-prof-deputy-costs-estimate-has-more-info>
-            <h3 class="label question bold">{{ 'moreInfo.form.profDeputyCostsEstimateHasMoreInfoSummary.yesno'|trans }}</h3>
-            <table class="checkboxes labelvalue inline">
-                <tr>                
-                    <td class="value checkbox">{% if report.profDeputyCostsEstimateHasMoreInfo == 'yes' %}X{% else %}&nbsp;{% endif %}</td>
-                    <td class="label">{{ 'yes' | trans({}, 'common') }}</td>
-                    <td class="value checkbox">{% if report.profDeputyCostsEstimateHasMoreInfo == 'no' %}X{% else %}&nbsp;{% endif %}</td>
-                    <td class="label">{{ 'no' | trans({}, 'common') }}</td>
-                </tr>
-            </table>
-            {% if report.profDeputyCostsEstimateHasMoreInfo == 'yes' %}
-            <div class="labelvalue push-half--top">
-                <div class="value">{{ report.profDeputyCostsEstimateMoreInfoDetails | capitalize | trans }}</div>
-            </div>
-            {% endif %}
-        </div>
-    </div>
     {% endif %}
 </div>

--- a/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_prof_deputy_costs_estimate.html.twig
@@ -27,7 +27,7 @@
                             {{ 'breakdown.form.profDeputyCostsEstimateManagementCost.label' | trans }}
                         </td>
                         <td class="value total width-half">
-                            £{{ (report.getProfDeputyManagementCostAmount) | money_format }}
+                            £{{ (report.profDeputyManagementCostAmount) | money_format }}
                         </td>
                     </tr>
                 </table>

--- a/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/_answers.html.twig
+++ b/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/_answers.html.twig
@@ -37,7 +37,7 @@
                     {{ 'breakdown.form.profDeputyCostsEstimateManagementCost.label' | trans }}
                 </td>
                 <td>
-                    £{{ (report.profDeputyManagementCostAmount) | money_format }}
+                    £{{ (report.getProfDeputyManagementCostAmount) | money_format }}
                 </td>
                 {% if not hideEditLink  %}
                     <td class="change-answer">

--- a/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/_answers.html.twig
+++ b/src/AppBundle/Resources/views/Report/ProfDeputyCostsEstimate/_answers.html.twig
@@ -37,7 +37,7 @@
                     {{ 'breakdown.form.profDeputyCostsEstimateManagementCost.label' | trans }}
                 </td>
                 <td>
-                    £{{ (report.getProfDeputyManagementCostAmount) | money_format }}
+                    £{{ (report.profDeputyManagementCostAmount) | money_format }}
                 </td>
                 {% if not hideEditLink  %}
                     <td class="change-answer">

--- a/tests/behat/features/prof/03-report/06-deputy-code-estimates.feature
+++ b/tests/behat/features/prof/03-report/06-deputy-code-estimates.feature
@@ -20,6 +20,7 @@ Feature: Prof deputy costs estimate
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "How will you be charging for your services?" in the "how-charged" region
     And I should see "Fixed costs" in the "how-charged" region
+    And I should not see "General management costs" in the "management-cost" region
     And I should not see "Contact with the client, their family and friends"
     And I should not see "Contact with case managers and care providers"
     And I should not see "Contact with other parties"
@@ -51,7 +52,7 @@ Feature: Prof deputy costs estimate
     And I click on "breadcrumbs-report-overview"
     Then I should see the "prof_deputy_costs_estimate-state-incomplete" region
 
-  Scenario: Completing the Assessed Costs route with no costs or more info and viewing the status overview
+  Scenario: Completing the Assessed Costs route with only management cost and viewing the status overview
     Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "pa-report-open" in the "client-01000013" region
     And I click on "edit-prof_deputy_costs_estimate"
@@ -67,6 +68,7 @@ Feature: Prof deputy costs estimate
     And the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "How will you be charging for your services?" in the "how-charged" region
     And I should see "Assessed costs" in the "how-charged" region
+    And I should see "4.99" in the "management-cost" region
     And I should see "Contact with the client, their family and friends" in the "breakdown-contact-client" region
     And I should see "£0.00" in the "breakdown-contact-client" region
     And I should see "Contact with case managers and care providers" in the "breakdown-contact-case-manager-carers" region
@@ -78,7 +80,7 @@ Feature: Prof deputy costs estimate
     And I should see "Other" in the "breakdown-other" region
     And I should see "£0.00" in the "breakdown-other" region
     And I should see "Total estimated costs" in the "total-estimate-cost" region
-    And I should see "£0.00" in the "total-estimate-cost" region
+    And I should see "£4.99" in the "total-estimate-cost" region
     And I should see "More information" in the "more-info" region
     And I should see "No" in the "more-info" region
     And I should not see "More information details" in the "more-info" region
@@ -108,6 +110,7 @@ Feature: Prof deputy costs estimate
     And the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "How will you be charging for your services?" in the "how-charged" region
     And I should see "Assessed costs" in the "how-charged" region
+    And I should see "4.99" in the "management-cost" region
     And I should see "Contact with the client, their family and friends" in the "breakdown-contact-client" region
     And I should see "£10.01" in the "breakdown-contact-client" region
     And I should see "Contact with case managers and care providers" in the "breakdown-contact-case-manager-carers" region
@@ -119,7 +122,7 @@ Feature: Prof deputy costs estimate
     And I should see "Other" in the "breakdown-other" region
     And I should see "£50.05" in the "breakdown-other" region
     And I should see "Total estimated costs" in the "total-estimate-cost" region
-    And I should see "£150.15" in the "total-estimate-cost" region
+    And I should see "£155.14" in the "total-estimate-cost" region
     And I should see "More information" in the "more-info" region
     And I should see "Yes" in the "more-info" region
     And I should see "More information details" in the "more-info-details" region
@@ -157,7 +160,7 @@ Feature: Prof deputy costs estimate
       | deputy_estimate_costs_profDeputyEstimateCosts_0_amount | 10.01 |
     And the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "Answer edited"
-    And I should see "£10.01" in the "total-estimate-cost" region
+    And I should see "£15.00" in the "total-estimate-cost" region
     When I click on "edit-breakdown-contact-case-manager-carers"
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/breakdown"
     And the step with the following values CAN be submitted:
@@ -165,7 +168,7 @@ Feature: Prof deputy costs estimate
       | deputy_estimate_costs_profDeputyEstimateCosts_1_amount | 20.02 |
     And the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "Answer edited"
-    And I should see "£30.03" in the "total-estimate-cost" region
+    And I should see "£35.02" in the "total-estimate-cost" region
     When I click on "edit-breakdown-contact-others"
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/breakdown"
     And the step with the following values CAN be submitted:
@@ -173,7 +176,7 @@ Feature: Prof deputy costs estimate
       | deputy_estimate_costs_profDeputyEstimateCosts_2_amount | 30.03 |
     And the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "Answer edited"
-    And I should see "£60.06" in the "total-estimate-cost" region
+    And I should see "£65.05" in the "total-estimate-cost" region
     When I click on "edit-breakdown-forms-documents"
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/breakdown"
     And the step with the following values CAN be submitted:
@@ -181,7 +184,7 @@ Feature: Prof deputy costs estimate
       | deputy_estimate_costs_profDeputyEstimateCosts_3_amount | 40.04 |
     And the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "Answer edited"
-    And I should see "£100.10" in the "total-estimate-cost" region
+    And I should see "105.09" in the "total-estimate-cost" region
     When I click on "edit-breakdown-other"
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/breakdown"
     And the step with the following values CAN be submitted:
@@ -233,6 +236,7 @@ Feature: Prof deputy costs estimate
       | deputy_costs_estimate_profDeputyCostsEstimateMoreInfoDetails | Extra text |
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "Assessed costs" in the "how-charged" region
+    And I should see "4.99" in the "management-cost" region
     And I should see "Contact with the client, their family and friends" in the "breakdown-contact-client" region
     And I should see "£0.00" in the "breakdown-contact-client" region
     And I should see "Contact with case managers and care providers" in the "breakdown-contact-case-manager-carers" region
@@ -244,7 +248,7 @@ Feature: Prof deputy costs estimate
     And I should see "Other" in the "breakdown-other" region
     And I should see "£0.00" in the "breakdown-other" region
     And I should see "Total estimated costs" in the "total-estimate-cost" region
-    And I should see "£30.03" in the "total-estimate-cost" region
+    And I should see "£35.02" in the "total-estimate-cost" region
     And I should see "More information" in the "more-info" region
     And I should see "Yes" in the "more-info" region
     And I should see "Extra text" in the "more-info-details" region
@@ -269,6 +273,7 @@ Feature: Prof deputy costs estimate
     And I should see "Answer edited"
     And I should see "How will you be charging for your services?" in the "how-charged" region
     And I should see "Fixed costs" in the "how-charged" region
+    And I should not see "General management costs"
     And I should not see "Contact with the client, their family and friends"
     And I should not see "Contact with case managers and care providers"
     And I should not see "Contact with other parties"

--- a/tests/behat/features/prof/03-report/06-deputy-code-estimates.feature
+++ b/tests/behat/features/prof/03-report/06-deputy-code-estimates.feature
@@ -20,7 +20,7 @@ Feature: Prof deputy costs estimate
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "How will you be charging for your services?" in the "how-charged" region
     And I should see "Fixed costs" in the "how-charged" region
-    And I should not see "General management costs" in the "management-cost" region
+    And I should not see "General management costs"
     And I should not see "Contact with the client, their family and friends"
     And I should not see "Contact with case managers and care providers"
     And I should not see "Contact with other parties"
@@ -193,7 +193,7 @@ Feature: Prof deputy costs estimate
       | deputy_estimate_costs_profDeputyEstimateCosts_4_moreDetails | info  |
     And the URL should match "/report/\d+/prof-deputy-costs-estimate/summary"
     And I should see "Answer edited"
-    And I should see "£150.15" in the "total-estimate-cost" region
+    And I should see "£155.14" in the "total-estimate-cost" region
     When I click on "edit-more-info-details"
     Then the URL should match "/report/\d+/prof-deputy-costs-estimate/more-info"
     And the step with the following values CAN be submitted:


### PR DESCRIPTION
Comparing to the previous branch in this piece of work (`Feature/DDPB-2458`) until its merged. Once `Feature/DDPB-2458` is merged I'll update the base branch to `feature-105`.

I don't see any tests related to the actual contents of the PDF preview so I've not added any assertions for that - if anyone thinks theres value in that let me know I can add something in.