### PR TITLE
Remove a misplaced character which was causing behat tests to fail

### DIFF
--- a/tests/behat/features/prof/03-report/06-deputy-code-estimates.feature
+++ b/tests/behat/features/prof/03-report/06-deputy-code-estimates.feature
@@ -75,7 +75,7 @@ Feature: Prof deputy costs estimate
     And I should see "£0.00" in the "breakdown-contact-case-manager-carers" region
     And I should see "Contact with other parties" in the "breakdown-contact-others" region
     And I should see "£0.00" in the "breakdown-contact-others" region
-    And I should see "Work on forms and other documents" in the "breakdown-forms-documents" regionƒ
+    And I should see "Work on forms and other documents" in the "breakdown-forms-documents" region
     And I should see "£0.00" in the "breakdown-forms-documents" region
     And I should see "Other" in the "breakdown-other" region
     And I should see "£0.00" in the "breakdown-other" region


### PR DESCRIPTION
An extra `ƒ` had snuck into the feature file, causing the command not to be matched and the tests to fail.