### PR TITLE
Validation fix

### DIFF
--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsEstimateTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsEstimateTrait.php
@@ -35,7 +35,7 @@ trait ReportProfDeputyCostsEstimateTrait
     /**
      * @var float
      *
-     * @JMS\Type("double")
+     * @JMS\Type("string")
      * @JMS\Groups({"prof-deputy-estimate-management-costs"})
      * @Assert\NotBlank( message="profDeputyEstimateCost.profDeputyManagementCostAmount.amount.notBlank", groups={"prof-deputy-estimate-management-costs"} )
      */

--- a/src/AppBundle/Form/Report/ProfDeputyEstimateCostsType.php
+++ b/src/AppBundle/Form/Report/ProfDeputyEstimateCostsType.php
@@ -16,6 +16,7 @@ class ProfDeputyEstimateCostsType extends AbstractType
             ->add('profDeputyManagementCostAmount', FormTypes\NumberType::class, [
                 'scale' => 2,
                 'error_bubbling' => false,
+                'grouping' => true,
                 'constraints' => new Valid(),
             ])
             ->add('profDeputyEstimateCosts', FormTypes\CollectionType::class, [

--- a/tests/behat/features/prof/03-report/06-deputy-code-estimates.feature
+++ b/tests/behat/features/prof/03-report/06-deputy-code-estimates.feature
@@ -342,23 +342,23 @@ Feature: Prof deputy costs estimate
     When I click on "start"
     Then the step cannot be submitted without making a selection
     When the step with the following values CAN be submitted:
-      | deputy_costs_estimate_profDeputyCostsEstimateHowCharged_0 | assessed |
+      | deputy_costs_estimate_profDeputyCostsEstimateHowCharged_0   | assessed |
     And the step with the following values CANNOT be submitted:
-      | deputy_estimate_costs_profDeputyManagementCostAmount        |       |
+      | deputy_estimate_costs_profDeputyManagementCostAmount        |          |
     And the step with the following values CAN be submitted:
-      | deputy_estimate_costs_profDeputyManagementCostAmount        | 4.99  |
+      | deputy_estimate_costs_profDeputyManagementCostAmount        | 1001.01  |
     Then the step cannot be submitted without making a selection
     And the step with the following values CANNOT be submitted:
-      | deputy_costs_estimate_profDeputyCostsEstimateHasMoreInfo_0   | yes |
-      | deputy_costs_estimate_profDeputyCostsEstimateMoreInfoDetails |     |
+      | deputy_costs_estimate_profDeputyCostsEstimateHasMoreInfo_0   | yes     |
+      | deputy_costs_estimate_profDeputyCostsEstimateMoreInfoDetails |         |
     And the step with the following values CAN be submitted:
-      | deputy_costs_estimate_profDeputyCostsEstimateHasMoreInfo_0  | no    |
+      | deputy_costs_estimate_profDeputyCostsEstimateHasMoreInfo_0   | no      |
     When I click on "edit-breakdown-contact-others"
     Then the step with the following values CANNOT be submitted:
-      | deputy_estimate_costs_profDeputyEstimateCosts_4_amount      | 30.03 |
-      | deputy_estimate_costs_profDeputyEstimateCosts_4_moreDetails |       |
+      | deputy_estimate_costs_profDeputyEstimateCosts_4_amount       | 30.03   |
+      | deputy_estimate_costs_profDeputyEstimateCosts_4_moreDetails  |         |
     When the step with the following values CAN be submitted:
-      | deputy_estimate_costs_profDeputyManagementCostAmount        | 4.99  |
-      | deputy_estimate_costs_profDeputyEstimateCosts_4_amount      | 30.03 |
-      | deputy_estimate_costs_profDeputyEstimateCosts_4_moreDetails | info  |
+      | deputy_estimate_costs_profDeputyManagementCostAmount         | 1001.01 |
+      | deputy_estimate_costs_profDeputyEstimateCosts_4_amount       | 30.03   |
+      | deputy_estimate_costs_profDeputyEstimateCosts_4_moreDetails  | info    |
 


### PR DESCRIPTION
As the form field didn't have grouping applied to it and the expected type was a `double`, validation errors were preventing any figure with 4 digits or more being entered for management costs as the field formatting would add a `,` when submitting the value in the POST.