### PR TITLE
 DDPB-2506: Deputy costs asking for SCCO figure with fixed costs

### DIFF
--- a/src/AppBundle/Controller/Report/ProfDeputyCostsController.php
+++ b/src/AppBundle/Controller/Report/ProfDeputyCostsController.php
@@ -398,8 +398,16 @@ class ProfDeputyCostsController extends AbstractController
             return $this->redirect($this->generateUrl('prof_deputy_costs_summary', ['reportId' => $reportId]));
         }
 
+        if ($form === 'summary') {
+            $backLink = 'prof_deputy_costs_summary';
+        } else if ($report->hasProfDeputyCostsHowChargedFixedOnly()) {
+            $backLink = 'prof_deputy_costs_received';
+        } else {
+            $backLink = 'prof_deputy_costs_amount_scco';
+        }
+
         return [
-            'backLink' =>$this->generateUrl( $from === 'summary' ? 'prof_deputy_costs_summary' : 'prof_deputy_costs_amount_scco', ['reportId'=>$reportId]),
+            'backLink' =>$this->generateUrl( $backLink, ['reportId'=>$reportId]),
             'form' => $form->createView(),
             'report' => $report,
         ];

--- a/src/AppBundle/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
+++ b/src/AppBundle/Resolver/SubSectionRoute/ProfCostsSubSectionRouteResolver.php
@@ -87,7 +87,7 @@ class ProfCostsSubSectionRouteResolver
             return self::COSTS_RECEIVED_ROUTE;
         }
 
-        return $this->amountSccoSubsectionIsIncomplete($report) ? self::SCCO_AMOUNT_ROUTE : self::SUMMARY_ROUTE;
+        return self::SUMMARY_ROUTE;
     }
 
     /**

--- a/tests/behat/features/prof/03-report/05-deputy-costs.feature
+++ b/tests/behat/features/prof/03-report/05-deputy-costs.feature
@@ -80,11 +80,6 @@ Feature: PROF deputy costs
       | deputy_costs_received_profDeputyFixedCost | 1000 |
     And I click on "breadcrumbs-report-overview"
     And I click on "edit-prof_deputy_costs"
-    Then the url should match "/report/\d+/prof-deputy-costs/amount-scco"
-    When the step with the following values CAN be submitted:
-      | deputy_costs_scco_profDeputyCostsAmountToScco | 100 |
-    And I click on "breadcrumbs-report-overview"
-    And I click on "edit-prof_deputy_costs"
     Then the url should match "/report/\d+/prof-deputy-costs/summary"
 
   Scenario: Entering partially completed sections with non Fixed costs and has interim


### PR DESCRIPTION
Stops deputies from being directed to the SCCO question if their costs are fixed.

Stops in two places:
- Clicking through from the report summary
- Pressing "Back" on the deputy costs breakdown screen