### PR TITLE
DDPB-2467: Fix translation for `totalEstimatedCosts` label

### DIFF
--- a/src/AppBundle/Resources/translations/admin-checklist.en.yml
+++ b/src/AppBundle/Resources/translations/admin-checklist.en.yml
@@ -139,6 +139,8 @@ checklistPage:
     satisfiedEstimatesNextBilling:
       label: |
         Are you satisfied with the deputy’s estimated costs for the next billing period?
+    totalEstimatedCosts:
+      label: Total estimated costs
     lodgingSummary:
       label: Lodging summary concerns and decisions
     finalDecision:

--- a/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -342,7 +342,7 @@
                 </tbody>
             </table>
             <h3>
-                {{ ('totalEstimatedCosts') | trans }}: 
+                {{ (page ~ '.form.totalEstimatedCosts.label') | trans({}, 'admin-checklist') }}: 
                 £{{ report.profDeputyEstimateCostsTotal | money_format }}
             </h3>
         </div>


### PR DESCRIPTION
Add translation text and fix usage of `trans`