### PR TITLE
DDPB-2517: Account for additional users/clients/reports in feature tests

### DIFF
--- a/tests/behat/features/deputy/02-ndr/10-submit.feature
+++ b/tests/behat/features/deputy/02-ndr/10-submit.feature
@@ -94,14 +94,14 @@ Feature: ndr / report submit
     @ndr
     Scenario: check NDR report not accessible after submission
         Given I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "Abcd1234"
-        And the URL "/ndr/1/visits-care/summary" should not be accessible
-        And the URL "/ndr/1/deputy-expenses/summary" should not be accessible
-        And the URL "/ndr/1/income-benefits/summary" should not be accessible
-        And the URL "/ndr/1/bank-accounts/summary" should not be accessible
-        And the URL "/ndr/1/assets/summary" should not be accessible
-        And the URL "/ndr/1/debts/summary" should not be accessible
-        And the URL "/ndr/1/actions/summary" should not be accessible
-        And the URL "/ndr/1/any-other-info/summary" should not be accessible
+        And the URL "/ndr/5/visits-care/summary" should not be accessible
+        And the URL "/ndr/5/deputy-expenses/summary" should not be accessible
+        And the URL "/ndr/5/income-benefits/summary" should not be accessible
+        And the URL "/ndr/5/bank-accounts/summary" should not be accessible
+        And the URL "/ndr/5/assets/summary" should not be accessible
+        And the URL "/ndr/5/debts/summary" should not be accessible
+        And the URL "/ndr/5/actions/summary" should not be accessible
+        And the URL "/ndr/5/any-other-info/summary" should not be accessible
 
     @ndr
     Scenario: NDR homepage and create new report

--- a/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -20,13 +20,13 @@ Feature: Report submit
         And I save the application status into "report-submit-pre"
         And I click on "report-start"
         # assert I cannot access the submitted page directly
-        And the URL "/report/1/submitted" should not be accessible
+        And the URL "/report/5/submitted" should not be accessible
         # assert I cannot access the submit page from declaration page
-        When I go to "/report/1/declaration"
-        Then the URL "/report/1/submitted" should not be accessible
+        When I go to "/report/5/declaration"
+        Then the URL "/report/5/submitted" should not be accessible
         And I click on "reports, report-start"
         # submit without ticking "agree"
-        When I go to "/report/1/declaration"
+        When I go to "/report/5/declaration"
         And I press "report_declaration_save"
         #
         # empty form
@@ -164,19 +164,19 @@ Feature: Report submit
     @deputy
     Scenario: assert report is not editable after submission
         Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
-        Then the URL "/report/1/overview" should not be accessible
-        And the URL "/report/1/decisions/summary" should not be accessible
-        And the URL "/report/1/contacts/summary" should not be accessible
-        And the URL "/report/1/visits-care/summary" should not be accessible
-        And the URL "/report/1/bank-accounts/summary" should not be accessible
-        And the URL "/report/1/money-transfers/summary" should not be accessible
-        And the URL "/report/1/money-in/summary" should not be accessible
-        And the URL "/report/1/money-out/summary" should not be accessible
-        And the URL "/report/1/balance" should not be accessible
-        And the URL "/report/1/assets/summary" should not be accessible
-        And the URL "/report/1/debts/summary" should not be accessible
-        And the URL "/report/1/actions" should not be accessible
-        And the URL "/report/1/declaration" should not be accessible
+        Then the URL "/report/5/overview" should not be accessible
+        And the URL "/report/5/decisions/summary" should not be accessible
+        And the URL "/report/5/contacts/summary" should not be accessible
+        And the URL "/report/5/visits-care/summary" should not be accessible
+        And the URL "/report/5/bank-accounts/summary" should not be accessible
+        And the URL "/report/5/money-transfers/summary" should not be accessible
+        And the URL "/report/5/money-in/summary" should not be accessible
+        And the URL "/report/5/money-out/summary" should not be accessible
+        And the URL "/report/5/balance" should not be accessible
+        And the URL "/report/5/assets/summary" should not be accessible
+        And the URL "/report/5/debts/summary" should not be accessible
+        And the URL "/report/5/actions" should not be accessible
+        And the URL "/report/5/declaration" should not be accessible
 
     @deputy
     Scenario: deputy report download

--- a/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -6,7 +6,7 @@ Feature: Admin unsubmit report (from client page)
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "admin-client-search"
     Then each text should be present in the corresponding region:
-      | 8 clients | client-search-count |
+      | 12 clients | client-search-count |
     Then each text should be present in the corresponding region:
       | Cly Hent | client-behat001 |
     When I fill in the following:

--- a/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -6,7 +6,7 @@ Feature: Admin report checklist
     # Navigate to checklist via search
     And I click on "admin-client-search"
     Then each text should be present in the corresponding region:
-      | 8 clients | client-search-count |
+      | 12 clients | client-search-count |
     Then each text should be present in the corresponding region:
       | Cly Hent | client-behat001 |
     When I fill in the following:

--- a/tests/behat/features/deputy/05-acl/02-pages-security.feature
+++ b/tests/behat/features/deputy/05-acl/02-pages-security.feature
@@ -40,38 +40,38 @@ Feature: deputy / acl / security on pages
     Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
     And I save the application status into "deputy-acl-before"
     Then the following "client" pages should return the following status:
-      | /report/1/overview         | 200 |
+      | /report/5/overview         | 200 |
       # decisions
-      | /report/1/decisions        | 200 |
+      | /report/5/decisions        | 200 |
       # contacts
-      | /report/1/contacts         | 200 |
-      | /report/1/contacts/add     | 200 |
+      | /report/5/contacts         | 200 |
+      | /report/5/contacts/add     | 200 |
       # assets
-      | /report/1/assets           | 200 |
-      | /report/1/assets/step-type | 200 |
+      | /report/5/assets           | 200 |
+      | /report/5/assets/step-type | 200 |
       # accounts
-      | /report/1/bank-accounts    | 200 |
+      | /report/5/bank-accounts    | 200 |
     # behat-malicious CANNOT access the same URLs
     Given I am logged in as "behat-malicious@publicguardian.gov.uk" with password "Abcd1234"
     # reload the status (as some URLs calls might have deleted data)
     And I load the application status from "deputy-acl-before"
     Then the following "client" pages should return the following status:
-      | /report/2/overview                | 200 |
-      | /report/1/overview                | 500 |
+      | /report/6/overview                | 200 |
+      | /report/5/overview                | 500 |
       # decisions
-      | /report/2/decisions               | 200 |
-      | /report/1/decisions               | 500 |
+      | /report/6/decisions               | 200 |
+      | /report/5/decisions               | 500 |
       # contacts
-      | /report/2/contacts                | 200 |
-      | /report/1/contacts                | 500 |
+      | /report/6/contacts                | 200 |
+      | /report/5/contacts                | 500 |
       # assets
-      | /report/2/assets                  | 200 |
-      | /report/1/assets                  | 500 |
+      | /report/6/assets                  | 200 |
+      | /report/5/assets                  | 500 |
       # accounts
-      | /report/1/bank-accounts           | 500 |
+      | /report/5/bank-accounts           | 500 |
       # submit
-      | /report/1/declaration             | 500 |
-      | /report/1/submitted               | 500 |
+      | /report/5/declaration             | 500 |
+      | /report/5/submitted               | 500 |
     And I load the application status from "deputy-acl-before"
 
     


### PR DESCRIPTION
In DDPB-2517, we are adding new fixture users so that testers can easily log in as professional and PA deputies. We also auto-populate some reports to ensure they are accessible by testers.

These changes requires automated feature tests to be updated to account for the new records. This occurs in two ways:

* Updating the count of clients
* Updating the ID of reports to account for the auto-generated ones

Admittedly these are "magic numbers" tests, and probably not what we want to be doing. However, these changes aren't adding new magic numbers, and they put us in a better position to refactor our tests going forward (for example by using fixture users rather than ones created in tests).