### PR TITLE
DDPB-2465 fix validation errors

### DIFF
--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -201,11 +201,11 @@ trait ReportProfDeputyCostsTrait
     {
         $ics = $this->getProfDeputyInterimCosts();
 
-        foreach($this->getProfDeputyInterimCosts() as $index => $ic) {
+        foreach($ics as $index => $ic) {
             if ($ics[$index]->getDate() === null && $ics[$index]->getAmount() === null) {
                 return;
             }
-            
+
             if ($ics[$index]->getDate() === null) {
                 $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath(sprintf('profDeputyInterimCosts[%s].date', $index))->addViolation();
             }

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -4,6 +4,7 @@ namespace AppBundle\Entity\Report\Traits;
 
 use AppBundle\Entity\Report\ProfDeputyOtherCost;
 use JMS\Serializer\Annotation as JMS;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Validator\Constraints as Assert;
 use AppBundle\Entity\Report\ProfDeputyPreviousCost;
 use AppBundle\Entity\Report\ProfDeputyInterimCost;
@@ -199,18 +200,26 @@ trait ReportProfDeputyCostsTrait
      */
     public function profCostsInterimAtLeastOne(ExecutionContextInterface $context)
     {
-        // skip validation if there is at least one interim with date
-        foreach($this->getProfDeputyInterimCosts() as $ic) {
-            if (!empty($ic->getAmount()) && !empty($ic->getDate())) {
+        /** @var Form $form */
+        $interimCostsFormValues = $context->getRoot()->get('profDeputyInterimCosts')->getData();
+        $violations = [];
+
+        foreach($interimCostsFormValues as $ic) {
+            if ($ic->getAmount() == null) {
+                $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath('profDeputyInterimCosts[0].amount')->addViolation();
+                $violations[] = "amount";
+            }
+
+            if ($ic->getDate() == null) {
+                $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath('profDeputyInterimCosts[0].date')->addViolation();
+                $violations[] = "date";
+            }
+
+            if (!empty($violations)) {
                 return;
             }
         }
-
-        $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath('profDeputyInterimCosts[0].amount')->addViolation();
-        $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath('profDeputyInterimCosts[0].date')->addViolation();
     }
-
-
 
     /**
      * @return string

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -200,29 +200,15 @@ trait ReportProfDeputyCostsTrait
      */
     public function profCostsInterimAtLeastOne(ExecutionContextInterface $context)
     {
-        $violations = [];
         $ics = $this->getProfDeputyInterimCosts();
 
-        if ($ics[0]->getAmount() === null) {
-            $violations[] = 'amount';
-        }
-
         if ($ics[0]->getDate() === null) {
-            $violations[] = 'date';
-        }
-
-        if (empty($violations)) {
-            return;
-        }
-
-        if (in_array('date', $violations)) {
             $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath('profDeputyInterimCosts[0].date')->addViolation();
         }
 
-        if (in_array('amount', $violations)) {
+        if ($ics[0]->getAmount() === null) {
             $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath('profDeputyInterimCosts[0].amount')->addViolation();
         }
-
     }
 
     /**

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -202,12 +202,14 @@ trait ReportProfDeputyCostsTrait
         $ics = $this->getProfDeputyInterimCosts();
 
         if (!empty($ics)) {
-            if ($ics[0]->getDate() === null) {
-                $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath('profDeputyInterimCosts[0].date')->addViolation();
-            }
+            foreach($this->getProfDeputyInterimCosts() as $index => $ic) {
+                if ($ics[$index]->getDate() === null) {
+                    $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath(sprintf('profDeputyInterimCosts[%s].date', $index))->addViolation();
+                }
 
-            if ($ics[0]->getAmount() === null) {
-                $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath('profDeputyInterimCosts[0].amount')->addViolation();
+                if ($ics[$index]->getAmount() === null) {
+                    $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath(sprintf('profDeputyInterimCosts[%s].amount', $index))->addViolation();
+                }
             }
         }
 

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -200,25 +200,29 @@ trait ReportProfDeputyCostsTrait
      */
     public function profCostsInterimAtLeastOne(ExecutionContextInterface $context)
     {
-        /** @var Form $form */
-        $interimCostsFormValues = $context->getRoot()->get('profDeputyInterimCosts')->getData();
         $violations = [];
+        $ics = $this->getProfDeputyInterimCosts();
 
-        foreach($interimCostsFormValues as $ic) {
-            if ($ic->getAmount() == null) {
-                $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath('profDeputyInterimCosts[0].amount')->addViolation();
-                $violations[] = "amount";
-            }
-
-            if ($ic->getDate() == null) {
-                $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath('profDeputyInterimCosts[0].date')->addViolation();
-                $violations[] = "date";
-            }
-
-            if (!empty($violations)) {
-                return;
-            }
+        if ($ics[0]->getAmount() === null) {
+            $violations[] = 'amount';
         }
+
+        if ($ics[0]->getDate() === null) {
+            $violations[] = 'date';
+        }
+
+        if (empty($violations)) {
+            return;
+        }
+
+        if (in_array('date', $violations)) {
+            $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath('profDeputyInterimCosts[0].date')->addViolation();
+        }
+
+        if (in_array('amount', $violations)) {
+            $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath('profDeputyInterimCosts[0].amount')->addViolation();
+        }
+
     }
 
     /**

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -4,7 +4,6 @@ namespace AppBundle\Entity\Report\Traits;
 
 use AppBundle\Entity\Report\ProfDeputyOtherCost;
 use JMS\Serializer\Annotation as JMS;
-use Symfony\Component\Form\Form;
 use Symfony\Component\Validator\Constraints as Assert;
 use AppBundle\Entity\Report\ProfDeputyPreviousCost;
 use AppBundle\Entity\Report\ProfDeputyInterimCost;

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -201,13 +201,16 @@ trait ReportProfDeputyCostsTrait
     {
         $ics = $this->getProfDeputyInterimCosts();
 
-        if ($ics[0]->getDate() === null) {
-            $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath('profDeputyInterimCosts[0].date')->addViolation();
+        if (!empty($ics)) {
+            if ($ics[0]->getDate() === null) {
+                $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath('profDeputyInterimCosts[0].date')->addViolation();
+            }
+
+            if ($ics[0]->getAmount() === null) {
+                $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath('profDeputyInterimCosts[0].amount')->addViolation();
+            }
         }
 
-        if ($ics[0]->getAmount() === null) {
-            $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath('profDeputyInterimCosts[0].amount')->addViolation();
-        }
     }
 
     /**

--- a/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
+++ b/src/AppBundle/Entity/Report/Traits/ReportProfDeputyCostsTrait.php
@@ -201,18 +201,19 @@ trait ReportProfDeputyCostsTrait
     {
         $ics = $this->getProfDeputyInterimCosts();
 
-        if (!empty($ics)) {
-            foreach($this->getProfDeputyInterimCosts() as $index => $ic) {
-                if ($ics[$index]->getDate() === null) {
-                    $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath(sprintf('profDeputyInterimCosts[%s].date', $index))->addViolation();
-                }
+        foreach($this->getProfDeputyInterimCosts() as $index => $ic) {
+            if ($ics[$index]->getDate() === null && $ics[$index]->getAmount() === null) {
+                return;
+            }
+            
+            if ($ics[$index]->getDate() === null) {
+                $context->buildViolation('profDeputyInterimCost.date.notBlank')->atPath(sprintf('profDeputyInterimCosts[%s].date', $index))->addViolation();
+            }
 
-                if ($ics[$index]->getAmount() === null) {
-                    $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath(sprintf('profDeputyInterimCosts[%s].amount', $index))->addViolation();
-                }
+            if ($ics[$index]->getAmount() === null) {
+                $context->buildViolation('profDeputyInterimCost.atLeastOne')->atPath(sprintf('profDeputyInterimCosts[%s].amount', $index))->addViolation();
             }
         }
-
     }
 
     /**

--- a/src/AppBundle/Validator/Constraints/EndDateNotBeforeStartDateValidator.php
+++ b/src/AppBundle/Validator/Constraints/EndDateNotBeforeStartDateValidator.php
@@ -28,7 +28,7 @@ class EndDateNotBeforeStartDateValidator extends ConstraintValidator
             $this
                 ->context
                 ->buildViolation($constraint->message)
-                ->addViolation();
+                ->atPath('endDate')->addViolation();
         }
     }
 }


### PR DESCRIPTION
I've had to rejig the validation callback function here as if we had a valid value in amount but an invalid value in date we were still getting a validation error for the amount due to the  `!empty($ic->getAmount()) && !empty($ic->getDate()` check. 

I'd taken the intent of the function to be checking for just one interim cost and associated date to exist hence why I dropped the `foreach` and moved to checking the first index of the `interimCosts` array.