### PR TITLE
DDPB-2331 Change to use client name for visits and care

### DIFF
--- a/src/AppBundle/Resources/translations/report-assets.en.yml
+++ b/src/AppBundle/Resources/translations/report-assets.en.yml
@@ -64,6 +64,10 @@ summaryPage:
   totalValueOfAssets: Total value of assets
 
 form:
+  clientAssets.label: %client%'s assets
+  doesClientHaveAssets: 
+    label: Does %client% own any assets?
+    noAssets.label: %client% has no assets
   titleSave.label: Save and continue
   title:
     label: What sort of asset is it?

--- a/src/AppBundle/Resources/translations/report-debts.en.yml
+++ b/src/AppBundle/Resources/translations/report-debts.en.yml
@@ -37,6 +37,10 @@ summaryPage:
   moreAbout: %client%'s other debts of £%amount%
 
 form:
+  clientsDebts.label: %client%'s debts
+  doesClientHaveDebts:
+    label: Does %client% have any debts?
+    noDebts.label: %client% has no debts
   entries:
     care-fees:
       label: Outstanding care home fees

--- a/src/AppBundle/Resources/translations/report-visits-care.en.yml
+++ b/src/AppBundle/Resources/translations/report-visits-care.en.yml
@@ -24,9 +24,9 @@ form:
     hint: ""
   howOftenDoYouContactClient:
     label: |
-      Please tell us how often you have contact with %client% and how you make sure others are looking
+      Please tell us how often do you have contact with %client% and how do you make sure others are looking
       after %client%'s needs when you're not able to.
-    labelShort: How often you have contact with %client% and how you make sure others are looking after %client%'s needs when you're not able to
+    labelShort: How often do you have contact with %client% and how do you make sure others are looking after %client%'s needs when you're not able to
   doesClientReceivePaidCare:
     label: Does %client% receive care that is paid for?
     hint: This includes private residential care or home visits from a care worker - but not help from unpaid carers such as family and friends

--- a/src/AppBundle/Resources/translations/report-visits-care.en.yml
+++ b/src/AppBundle/Resources/translations/report-visits-care.en.yml
@@ -26,18 +26,17 @@ form:
     label: |
       Please tell us how often you have contact with %client% and how you make sure others are looking
       after %client%'s needs when you're not able to.
-    labelShort: Please tell us how often you have contact with %client%.
-    hint: ""
+    labelShort: How often you have contact with %client% and how you make sure others are looking after %client%'s needs when you're not able to
   doesClientReceivePaidCare:
-    label: Does %client% get care that is paid for?
+    label: Does %client% receive care that is paid for?
     hint: This includes private residential care or home visits from a care worker - but not help from unpaid carers such as family and friends
   howIsCareFunded:
     label: How is the care funded?
     hint: ""
     choices:
       client_pays_for_all: %client% pays for all the care
-      client_gets_financial_help: %client% gets some financial help (for example, from the local authority or NHS)
-      all_care_is_paid_by_someone_else: All  %client%'s care is paid for by someone else (for example, by the local authority or NHS)
+      client_gets_financial_help: %client% gets some financial help (for example, from the local authority, council or NHS)
+      all_care_is_paid_by_someone_else: All  %client%'s care is paid for by someone else (for example, by the local authority, council or NHS)
   whoIsDoingTheCaring:
     label: Who is doing the caring?
     hint: For example, local authority or private residential care workers, live-in or visiting care workers, family members

--- a/src/AppBundle/Resources/views/Macros/macros-review.html.twig
+++ b/src/AppBundle/Resources/views/Macros/macros-review.html.twig
@@ -79,11 +79,11 @@
 {# =================================================================== #}
 {# Visits and care #}
 
-{% macro careArrangements(visitsCare) %}
+{% macro careArrangements(visitsCare, transOptions) %}
 <div class="dont-break">
     <h3>Care arrangements</h3>
     <div class="box" id="care-arrangements-subsection">
-        <h3 class="label question bold">Does the client receive care which is paid for?</h3>
+        <h3 class="label question bold">{{ 'form.doesClientReceivePaidCare.label' | trans(transOptions, 'report-visits-care') }}</h3>
 
         <table class="checkboxes labelvalue inline">
             <tr>
@@ -103,7 +103,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_pays_for_all' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label soft-half--bottom">Client pays for all their own care</td>
+                    <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_pays_for_all' | trans(transOptions, 'report-visits-care') }}</td>
                 </tr>
                 <tr>
                     <td class="clean-cell">
@@ -111,7 +111,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_gets_financial_help' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label soft-half--bottom">Client gets some financial help (for example, from the local authority or council, or NHS)</td>
+                    <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_gets_financial_help' | trans(transOptions, 'report-visits-care') }}</td>
                 </tr>
                 <tr>
                     <td class="clean-cell">
@@ -119,7 +119,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'all_care_is_paid_by_someone_else' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label hard--ends">All care is paid for by someone else (for example, by the local authority or council, or NHS)</td>
+                    <td class="label hard--ends">{{ 'form.howIsCareFunded.choices.all_care_is_paid_by_someone_else' | trans(transOptions, 'report-visits-care') }}</td>
                 </tr>
             </table>
         </div>

--- a/src/AppBundle/Resources/views/Macros/macros-review.html.twig
+++ b/src/AppBundle/Resources/views/Macros/macros-review.html.twig
@@ -79,11 +79,11 @@
 {# =================================================================== #}
 {# Visits and care #}
 
-{% macro careArrangements(visitsCare, transOptions) %}
+{% macro careArrangements(visitsCare, transOptions, translationDomain) %}
 <div class="dont-break">
     <h3>Care arrangements</h3>
     <div class="box" id="care-arrangements-subsection">
-        <h3 class="label question bold">{{ 'form.doesClientReceivePaidCare.label' | trans(transOptions, 'report-visits-care') }}</h3>
+        <h3 class="label question bold">{{ 'form.doesClientReceivePaidCare.label' | trans(transOptions, translationDomain) }}</h3>
 
         <table class="checkboxes labelvalue inline">
             <tr>
@@ -103,7 +103,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_pays_for_all' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_pays_for_all' | trans(transOptions, 'report-visits-care') }}</td>
+                    <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_pays_for_all' | trans(transOptions, translationDomain) }}</td>
                 </tr>
                 <tr>
                     <td class="clean-cell">
@@ -111,7 +111,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_gets_financial_help' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_gets_financial_help' | trans(transOptions, 'report-visits-care') }}</td>
+                    <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_gets_financial_help' | trans(transOptions, translationDomain) }}</td>
                 </tr>
                 <tr>
                     <td class="clean-cell">
@@ -119,7 +119,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'all_care_is_paid_by_someone_else' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label hard--ends">{{ 'form.howIsCareFunded.choices.all_care_is_paid_by_someone_else' | trans(transOptions, 'report-visits-care') }}</td>
+                    <td class="label hard--ends">{{ 'form.howIsCareFunded.choices.all_care_is_paid_by_someone_else' | trans(transOptions, translationDomain) }}</td>
                 </tr>
             </table>
         </div>

--- a/src/AppBundle/Resources/views/Ndr/Formatted/_visits-care.html.twig
+++ b/src/AppBundle/Resources/views/Ndr/Formatted/_visits-care.html.twig
@@ -1,3 +1,4 @@
+{% set translationDomain = "ndr-visits-care" %}
 {% import 'AppBundle:Macros:macros-review.html.twig' as macros %}
 
 {% set visitsCare = ndr.visitsCare %}
@@ -5,17 +6,17 @@
     <h2 class="section-heading">Visits and care</h2>
 
     {{ macros.answerYesNo({
-        question: 'Do you live with the client',
+        question: 'form.doYouLiveWithClient.label' | trans(transOptions, translationDomain),
         answer: visitsCare.doYouLiveWithClient,
         moreDetails: visitsCare.howOftenDoYouContactClient,
         moreDetailsLabel: 'How often do you contact the client and how do you make sure others are looking after the client\'s needs if you can\'t ?',
         showMoreDetailsWith: 'no'
     }) }}
 
-    {{ macros.careArrangements(visitsCare) }}
+    {{ macros.careArrangements(visitsCare, transOptions, translationDomain) }}
 
     {{ macros.answerYesNo({
-        question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, 'ndr-visits-care'),
+        question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, translationDomain),
         answer: visitsCare.doesClientHaveACarePlan,
         moreDetails: visitsCare.whenWasCarePlanLastReviewed | date("m / Y"),
         moreDetailsLabel: 'Review date',
@@ -23,7 +24,7 @@
     }) }}
 
     {{ macros.answerYesNo({
-        question: 'Are there any plans for the client to move to a new residence',
+        question: 'form.planMoveNewResidence.label' | trans(transOptions, translationDomain),
         answer: visitsCare.planMoveNewResidence,
         moreDetails: visitsCare.planMoveNewResidenceDetails,
         showMoreDetailsWith: 'yes'

--- a/src/AppBundle/Resources/views/Report/Formatted/_assets.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_assets.html.twig
@@ -1,14 +1,15 @@
+{% set translationDomain = "report-assets" %}
 {% if assets | length > 0 or report.noAssetToAdd == true %}
     <div class="section break-before" id="assets-section">
-        <h2 class="section-heading">Client's assets</h2>
+        <h2 class="section-heading">{{ 'form.clientAssets.label' | trans(transOptions, translationDomain) }}</h2>
 
         {% if report.assets | length == 0 %}
             <div class="box">
-                <h3 class="label question bold">Does the client have any assets?</h3>
+                <h3 class="label question bold">{{ 'form.doesClientHaveAssets.label' | trans(transOptions, translationDomain) }}</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
                         <td class="value checkbox">X</td>
-                        <td class="label">My client has no assets</td>
+                        <td class="label">{{ 'form.doesClientHaveAssets.noAssets.label' | trans(transOptions, translationDomain) }}</td>
                     </tr>
                 </table>
             </div>

--- a/src/AppBundle/Resources/views/Report/Formatted/_debts.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_debts.html.twig
@@ -3,15 +3,15 @@
 {% trans_default_domain translationDomain %}
 
 <div class="section break-before" id="debts-section">
-    <h2 class="section-heading">Client's debts</h2>
+    <h2 class="section-heading">{{ 'form.clientsDebts.label' | trans(transOptions, translationDomain) }}</h2>
 
     {% if report.hasDebts == 'no' %}
         <div class="box">
-            <h3 class="label question bold">Does the client have any debts?</h3>
+            <h3 class="label question bold">{{ 'form.doesClientHaveDebts.label' | trans(transOptions, translationDomain) }}</h3>
             <table class="checkboxes labelvalue inline">
                 <tr>
                     <td class="value checkbox">X</td>
-                    <td class="label">My client has no debts</td>
+                    <td class="label">{{ 'form.doesClientHaveDebts.noDebts.label' | trans(transOptions, translationDomain) }}</td>
                 </tr>
             </table>
         </div>

--- a/src/AppBundle/Resources/views/Report/Formatted/_visits_care.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_visits_care.html.twig
@@ -4,14 +4,14 @@
     <h2 class="section-heading">Visits and care</h2>
 
     {{ macros.answerYesNo({
-        question: 'Do you live with the client',
+        question: 'form.doYouLiveWithClient.label' | trans(transOptions, 'report-visits-care'),
         answer: visitsCare.doYouLiveWithClient,
         moreDetails: visitsCare.howOftenDoYouContactClient,
-        moreDetailsLabel: 'How often do you contact the client and how do you make sure others are looking after the client\'s needs if you can\'t ?',
+        moreDetailsLabel: 'form.howOftenDoYouContactClient.labelShort' | trans(transOptions, 'report-visits-care'),
         showMoreDetailsWith: 'no'
     }) }}
 
-    {{ macros.careArrangements(visitsCare) }}
+    {{ macros.careArrangements(visitsCare, transOptions) }}
 
     {{ macros.answerYesNo({
         question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, 'report-visits-care'),

--- a/src/AppBundle/Resources/views/Report/Formatted/_visits_care.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_visits_care.html.twig
@@ -1,20 +1,21 @@
+{% set translationDomain = "report-visits-care" %}
 {% import 'AppBundle:Macros:macros-review.html.twig' as macros %}
 
 <div class="section" id="safeguarding-section">
     <h2 class="section-heading">Visits and care</h2>
 
     {{ macros.answerYesNo({
-        question: 'form.doYouLiveWithClient.label' | trans(transOptions, 'report-visits-care'),
+        question: 'form.doYouLiveWithClient.label' | trans(transOptions, translationDomain),
         answer: visitsCare.doYouLiveWithClient,
         moreDetails: visitsCare.howOftenDoYouContactClient,
-        moreDetailsLabel: 'form.howOftenDoYouContactClient.labelShort' | trans(transOptions, 'report-visits-care'),
+        moreDetailsLabel: 'form.howOftenDoYouContactClient.labelShort' | trans(transOptions, translationDomain),
         showMoreDetailsWith: 'no'
     }) }}
 
-    {{ macros.careArrangements(visitsCare, transOptions) }}
+    {{ macros.careArrangements(visitsCare, transOptions, translationDomain) }}
 
     {{ macros.answerYesNo({
-        question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, 'report-visits-care'),
+        question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, translationDomain),
         answer: visitsCare.doesClientHaveACarePlan,
         moreDetails: visitsCare.whenWasCarePlanLastReviewed | date("m / Y"),
         moreDetailsLabel: 'Review date',


### PR DESCRIPTION
Some translations had to be modified and used as before they
weren't on the macro for visits and care. Transoptions passed in
so we can use translations for the strings. Mainly so that we
can see the client name on the review / pdf instead of
"the client"