### PR TITLE
DDPB-2551: improves performance of Settings index for Org deputies

### DIFF
--- a/src/AppBundle/Controller/SettingsController.php
+++ b/src/AppBundle/Controller/SettingsController.php
@@ -20,6 +20,10 @@ class SettingsController extends AbstractController
      **/
     public function indexAction()
     {
+        if ($this->getUser()->isDeputyOrg()) {
+            return [];
+        };
+
         // redirect if user has missing details or is on wrong page
         $user = $this->getUserWithData(['user-clients', 'client', 'client-reports', 'report']);
         if ($route = $this->get('redirector_service')->getCorrectRouteIfDifferent($user, 'account_settings')) {


### PR DESCRIPTION
Plenty of ways to fix this, but the quickest win is to just return straight to the template when a non Lay user is at the page - only Lay user's need to do the API lookup to extract client information, which is the cause of the unnecessary bottleneck for non Lay's.