### PR TITLE
DDPB-2537 - Rename an un-submitted Pro/PA report in dashboard

### DIFF
--- a/docker/confd/templates/parameters.yml.tmpl
+++ b/docker/confd/templates/parameters.yml.tmpl
@@ -27,6 +27,9 @@ parameters:
     email_feedback_send:
         from_email: noreply-opgdeputyservice@{{ getv "/frontend/email/domain" }}
         to_email: {{ getv "/frontend/email/feedback/to" }}
+    email_update_send:
+        from_email: noreply-opgdeputyservice@{{ getv "/frontend/email/domain" }}
+        to_email: {{ getv "/frontend/email/update/to" }}
     smtp_default_hostname: {{ getv "/frontend/smtp/default/hostname" }}
     smtp_default_port: {{ getv "/frontend/smtp/default/port" }}
     smtp_default_user: {{ getv "/frontend/smtp/default/user" }}

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -49,6 +49,13 @@ class ClientController extends AbstractController
             $this->getRestClient()->put('client/upsert', $clientUpdated, ['edit']);
             $request->getSession()->getFlashBag()->add('notice', htmlentities($client->getFirstname()) . "'s data edited");
 
+            $user = $this->getUserWithData(['user-clients', 'client']);
+
+            if ($user->isLayDeputy()) {
+                $addressUpdateEmail = $this->getMailFactory()->createAddressUpdateEmail($form->getData(), $user, 'client');
+                $this->getMailSender()->send($addressUpdateEmail, ['html']);
+            }
+
             return $this->redirect($this->generateUrl('client_show'));
         }
 

--- a/src/AppBundle/Controller/SettingsController.php
+++ b/src/AppBundle/Controller/SettingsController.php
@@ -136,6 +136,12 @@ class SettingsController extends AbstractController
             try {
                 $this->getRestClient()->put('user/' . $user->getId(), $formData, $jmsPutGroups);
 
+                if ($user->isLayDeputy()) {
+                    $groups = ['user-clients', 'client'];
+                    $addressUpdateEmail = $this->getMailFactory()->createAddressUpdateEmail($form->getData(), $this->getUserWithData($groups), 'deputy');
+                    $this->getMailSender()->send($addressUpdateEmail, ['html']);
+                }
+
                 return $this->redirectToRoute($redirectRoute);
             } catch (\Exception $e) {
                 $translator = $this->get('translator');

--- a/src/AppBundle/Controller/SettingsController.php
+++ b/src/AppBundle/Controller/SettingsController.php
@@ -20,6 +20,10 @@ class SettingsController extends AbstractController
      **/
     public function indexAction()
     {
+        if ($this->getUser()->isDeputyOrg()) {
+            return [];
+        };
+
         // redirect if user has missing details or is on wrong page
         $user = $this->getUserWithData(['user-clients', 'client', 'client-reports', 'report']);
         if ($route = $this->get('redirector_service')->getCorrectRouteIfDifferent($user, 'account_settings')) {

--- a/src/AppBundle/Resources/assets/scss/digideps/_status.scss
+++ b/src/AppBundle/Resources/assets/scss/digideps/_status.scss
@@ -77,4 +77,8 @@
         color: $white;
     }
 
+    &.changesNeeded {
+        border-color: $error-colour;
+        color: $error-colour;
+    }
 }

--- a/src/AppBundle/Resources/translations/common.en.yml
+++ b/src/AppBundle/Resources/translations/common.en.yml
@@ -97,6 +97,7 @@ inProgress: In progress
 submitted: Submitted
 unsubmitted: Unsubmitted
 notSavedYet: Not saved yet
+changesNeeded: Changes needed
 
 # Breadcrumbs
 yourReports: Your reports

--- a/src/AppBundle/Resources/translations/email.en.yml
+++ b/src/AppBundle/Resources/translations/email.en.yml
@@ -28,3 +28,12 @@ feedbackForm:
 codeputyInvitation:
     subject: Deputy report - activate your account now
     fromName: Office of the Public Guardian
+addressUpdateForm:
+    deputy:
+        subject: Change to deputy contact details
+        fromName: Deputy report service - deputy contact details updated
+        toName: Deputyship Service
+    client:
+        subject: Change to client contact details
+        fromName: Deputy report service - client contact details updated
+        toName: Deputyship Service

--- a/src/AppBundle/Resources/translations/report-assets.en.yml
+++ b/src/AppBundle/Resources/translations/report-assets.en.yml
@@ -64,6 +64,10 @@ summaryPage:
   totalValueOfAssets: Total value of assets
 
 form:
+  clientAssets.label: %client%'s assets
+  doesClientHaveAssets: 
+    label: Does %client% own any assets?
+    noAssets.label: %client% has no assets
   titleSave.label: Save and continue
   title:
     label: What sort of asset is it?

--- a/src/AppBundle/Resources/translations/report-debts.en.yml
+++ b/src/AppBundle/Resources/translations/report-debts.en.yml
@@ -37,6 +37,10 @@ summaryPage:
   moreAbout: %client%'s other debts of £%amount%
 
 form:
+  clientsDebts.label: %client%'s debts
+  doesClientHaveDebts:
+    label: Does %client% have any debts?
+    noDebts.label: %client% has no debts
   entries:
     care-fees:
       label: Outstanding care home fees

--- a/src/AppBundle/Resources/translations/report-overview.en.yml
+++ b/src/AppBundle/Resources/translations/report-overview.en.yml
@@ -21,6 +21,7 @@ status:
   notStarted: "Not started"
   notFinished: "Not finished"
   readyToSubmit: "Ready to submit"
+  changesNeeded: "Changes needed"
 reportDueDate: "Report due date"
 currentReport: "Current report"
 incompleteReport: "Incomplete report"

--- a/src/AppBundle/Resources/translations/report-visits-care.en.yml
+++ b/src/AppBundle/Resources/translations/report-visits-care.en.yml
@@ -24,20 +24,19 @@ form:
     hint: ""
   howOftenDoYouContactClient:
     label: |
-      Please tell us how often you have contact with %client% and how you make sure others are looking
+      Please tell us how often do you have contact with %client% and how do you make sure others are looking
       after %client%'s needs when you're not able to.
-    labelShort: Please tell us how often you have contact with %client%.
-    hint: ""
+    labelShort: How often do you have contact with %client% and how do you make sure others are looking after %client%'s needs when you're not able to
   doesClientReceivePaidCare:
-    label: Does %client% get care that is paid for?
+    label: Does %client% receive care that is paid for?
     hint: This includes private residential care or home visits from a care worker - but not help from unpaid carers such as family and friends
   howIsCareFunded:
     label: How is the care funded?
     hint: ""
     choices:
       client_pays_for_all: %client% pays for all the care
-      client_gets_financial_help: %client% gets some financial help (for example, from the local authority or NHS)
-      all_care_is_paid_by_someone_else: All  %client%'s care is paid for by someone else (for example, by the local authority or NHS)
+      client_gets_financial_help: %client% gets some financial help (for example, from the local authority, council or NHS)
+      all_care_is_paid_by_someone_else: All  %client%'s care is paid for by someone else (for example, by the local authority, council or NHS)
   whoIsDoingTheCaring:
     label: Who is doing the caring?
     hint: For example, local authority or private residential care workers, live-in or visiting care workers, family members

--- a/src/AppBundle/Resources/views/Admin/Client/Report/checklist.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Client/Report/checklist.html.twig
@@ -222,7 +222,7 @@
             {{ form_end(form) }}
         </div>
         <div class="column-third">
-            <aside class="govuk-related-items js-sidebar pull-above-title" role="complementary">
+            <aside class="govuk-related-items js-sidebar pull-above-title">
                 <h2 class="heading-small">{{ (page ~ '.heading.contents') | trans }}</h2>
                 <ul class="list font-xsmall">
                     <li><a href="#deputyAndClientInfo">{{ (page ~ '.heading.info') | trans }}</a></li>

--- a/src/AppBundle/Resources/views/Admin/Client/Report/partials/_deputy-and-client-info.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Client/Report/partials/_deputy-and-client-info.html.twig
@@ -61,7 +61,7 @@
                         <th scope="row" class="bold">{{ 'lastName' | trans({}, 'common') }}</th>
                         <td class="behat-region-checklist-client-lastname">{{ report.client.lastName }}</td>
                     </tr>
-                    <tr valign="top">
+                    <tr class="align--top">
                         <th scope="row" class="bold">{{ 'address' | trans({}, 'common') }}</th>
                         <td class="behat-region-checklist-client-address">
                             <p>
@@ -103,7 +103,7 @@
                         <th scope="row" class="bold">{{ 'lastName' | trans({}, 'common') }}</th>
                         <td class="behat-region-checklist-deputy-lastname">{{ deputy.lastname }}</td>
                     </tr>
-                    <tr valign="top">
+                    <tr class="align--top">
                         <th scope="row" class="bold">{{ 'address' | trans({}, 'common') }}</th>
                         <td class="behat-region-checklist-deputy-address">
                             <p>

--- a/src/AppBundle/Resources/views/Admin/Client/Report/partials/_money-in-and-out.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Client/Report/partials/_money-in-and-out.html.twig
@@ -77,7 +77,7 @@
                                 </tr>
                             {% endfor %}
                             <tr class="no-border">
-                                <td class="bold">{{ 'totalAmount' | trans({}, 'common') }}</span></td>
+                                <td class="bold">{{ 'totalAmount' | trans({}, 'common') }}</td>
                                 <td class="numeric-small">
                                     <span class="bold behat-region-checklist-accounts-opening-total">£{{ report.accountsOpeningBalanceTotal | money_format }}</span>
                                 </td>
@@ -119,7 +119,7 @@
                                 </tr>
                             {% endfor %}
                             <tr class="no-border">
-                                <td class="bold">{{ 'totalAmount' | trans({}, 'common') }}</span></td>
+                                <td class="bold">{{ 'totalAmount' | trans({}, 'common') }}</td>
                                 <td class="numeric-small">
                                     <span class="bold behat-region-checklist-accounts-closing-total">£{{ report.accountsClosingBalanceTotal | money_format }}</span>
                                 </td>

--- a/src/AppBundle/Resources/views/Email/address-update-client.html.twig
+++ b/src/AppBundle/Resources/views/Email/address-update-client.html.twig
@@ -1,0 +1,21 @@
+<p>The contact details of the following client have been updated:</p>
+
+<p><strong>Case number:</strong> {{ caseNumber }}</p>
+
+<p><strong>Name:</strong> {{ response.fullName }}</p>
+
+<p>
+    <strong>Address line 1:</strong> {{ response.address }} <br />
+    <strong>Address line 2:</strong> {{ response.address2 }} <br />
+    <strong>Address line 3:</strong> {{ response.county }} <br />
+    <strong>Postcode:</strong> {{ response.postcode }} <br />
+    <strong>Country:</strong> {{ countryName }}
+</p>
+
+<p>
+    <strong>Phone number:</strong> {{ response.phone }}
+</p>
+
+<p>Please update Casrec with this information</p>
+
+<p>Sent from the Digideps service</p>

--- a/src/AppBundle/Resources/views/Email/address-update-deputy.html.twig
+++ b/src/AppBundle/Resources/views/Email/address-update-deputy.html.twig
@@ -1,0 +1,25 @@
+<p>The contact details of the following deputy have been updated:</p>
+
+<p><strong>Case number:</strong> {{ caseNumber }}</p>
+
+<p><strong>Name:</strong> {{ response.fullName }}</p>
+
+<p>
+    <strong>Address line 1:</strong> {{ response.address1 }} <br />
+    <strong>Address line 2:</strong> {{ response.address2 }} <br />
+    <strong>Address line 3:</strong> {{ response.address3 }} <br />
+    <strong>Postcode:</strong> {{ response.addressPostcode }} <br />
+    <strong>Country:</strong> {{ countryName }}
+</p>
+
+<p>
+    <strong>Phone number:</strong> {{ response.phoneMain }} <br />
+    <strong>Alternative phone number:</strong> {{ response.phoneAlternative }}
+</p>
+<p>
+    <strong>Email:</strong> {{ response.email }}
+</p>
+
+<p>Please update Casrec with this information</p>
+
+<p>Sent from the Digideps service</p>

--- a/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
+++ b/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
@@ -83,7 +83,7 @@
     <!--end global-cookie-message-->
 
 
-    <header role="banner" id="global-header" class="with-proposition {% block headerClass %}{% endblock %}">
+    <header id="global-header" class="with-proposition {% block headerClass %}{% endblock %}">
       <div class="header-wrapper {% if env == 'admin' %}wider{% endif %}">
         <div class="header-global">
           <div class="header-logo">
@@ -120,8 +120,7 @@
     {% block beforeContent %}{% endblock %}
 
     <div id="wrapper" class="group">
-      <a name="content"></a>
-      <main id="content" role="main" class="{% if env == 'admin' %}wider{% endif %}">
+      <main id="content" class="{% if env == 'admin' %}wider{% endif %}">
        {% block content %}{% endblock %}
    </main>
     </div>

--- a/src/AppBundle/Resources/views/Macros/macros-review.html.twig
+++ b/src/AppBundle/Resources/views/Macros/macros-review.html.twig
@@ -79,11 +79,11 @@
 {# =================================================================== #}
 {# Visits and care #}
 
-{% macro careArrangements(visitsCare) %}
+{% macro careArrangements(visitsCare, transOptions, translationDomain) %}
 <div class="dont-break">
     <h3>Care arrangements</h3>
     <div class="box" id="care-arrangements-subsection">
-        <h3 class="label question bold">Does the client receive care which is paid for?</h3>
+        <h3 class="label question bold">{{ 'form.doesClientReceivePaidCare.label' | trans(transOptions, translationDomain) }}</h3>
 
         <table class="checkboxes labelvalue inline">
             <tr>
@@ -103,7 +103,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_pays_for_all' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label soft-half--bottom">Client pays for all their own care</td>
+                    <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_pays_for_all' | trans(transOptions, translationDomain) }}</td>
                 </tr>
                 <tr>
                     <td class="clean-cell">
@@ -111,7 +111,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'client_gets_financial_help' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label soft-half--bottom">Client gets some financial help (for example, from the local authority or council, or NHS)</td>
+                    <td class="label soft-half--bottom">{{ 'form.howIsCareFunded.choices.client_gets_financial_help' | trans(transOptions, translationDomain) }}</td>
                 </tr>
                 <tr>
                     <td class="clean-cell">
@@ -119,7 +119,7 @@
                             {% if visitsCare.doesClientReceivePaidCare == 'yes' and visitsCare.howIsCareFunded == 'all_care_is_paid_by_someone_else' %}X{% else %}&nbsp;{% endif %}
                         </span>
                     </td>
-                    <td class="label hard--ends">All care is paid for by someone else (for example, by the local authority or council, or NHS)</td>
+                    <td class="label hard--ends">{{ 'form.howIsCareFunded.choices.all_care_is_paid_by_someone_else' | trans(transOptions, translationDomain) }}</td>
                 </tr>
             </table>
         </div>

--- a/src/AppBundle/Resources/views/Ndr/Formatted/_visits-care.html.twig
+++ b/src/AppBundle/Resources/views/Ndr/Formatted/_visits-care.html.twig
@@ -1,3 +1,4 @@
+{% set translationDomain = "ndr-visits-care" %}
 {% import 'AppBundle:Macros:macros-review.html.twig' as macros %}
 
 {% set visitsCare = ndr.visitsCare %}
@@ -5,17 +6,17 @@
     <h2 class="section-heading">Visits and care</h2>
 
     {{ macros.answerYesNo({
-        question: 'Do you live with the client',
+        question: 'form.doYouLiveWithClient.label' | trans(transOptions, translationDomain),
         answer: visitsCare.doYouLiveWithClient,
         moreDetails: visitsCare.howOftenDoYouContactClient,
         moreDetailsLabel: 'How often do you contact the client and how do you make sure others are looking after the client\'s needs if you can\'t ?',
         showMoreDetailsWith: 'no'
     }) }}
 
-    {{ macros.careArrangements(visitsCare) }}
+    {{ macros.careArrangements(visitsCare, transOptions, translationDomain) }}
 
     {{ macros.answerYesNo({
-        question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, 'ndr-visits-care'),
+        question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, translationDomain),
         answer: visitsCare.doesClientHaveACarePlan,
         moreDetails: visitsCare.whenWasCarePlanLastReviewed | date("m / Y"),
         moreDetailsLabel: 'Review date',
@@ -23,7 +24,7 @@
     }) }}
 
     {{ macros.answerYesNo({
-        question: 'Are there any plans for the client to move to a new residence',
+        question: 'form.planMoveNewResidence.label' | trans(transOptions, translationDomain),
         answer: visitsCare.planMoveNewResidence,
         moreDetails: visitsCare.planMoveNewResidenceDetails,
         showMoreDetailsWith: 'yes'

--- a/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail.html.twig
@@ -14,9 +14,11 @@
                 <strong class="bold">{{ 'reportStatus' | trans() }}</strong>
             </dt>
             <dd class="push--bottom">
-                <span class="status status-large {{ report.isUnsubmitted ? 'incomplete' : reportStatus.getState() }} flush--bottom">
-                    {{ ('status.' ~ reportStatus.status) | trans() }}
-                </span>
+                {% if report.submitted == false %}
+                    <span class="status status-large changesNeeded">{{ 'changesNeeded' | trans({}, 'common') }}</span>
+                {% else %}
+                    <span class="status status-large {{ reportStatus.getState() }} flush--bottom">{{ ('status.' ~ reportStatus.status) | trans() }}</span>
+                {% endif %}
             </dd>
 
             <dt class="visually-hidden">

--- a/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/_reportDetail.html.twig
@@ -14,7 +14,7 @@
                 <strong class="bold">{{ 'reportStatus' | trans() }}</strong>
             </dt>
             <dd class="push--bottom">
-                {% if report.submitted == false %}
+                {% if report.unSubmitDate != null and report.submitted == false %}
                     <span class="status status-large changesNeeded">{{ 'changesNeeded' | trans({}, 'common') }}</span>
                 {% else %}
                     <span class="status status-large {{ reportStatus.getState() }} flush--bottom">{{ ('status.' ~ reportStatus.status) | trans() }}</span>

--- a/src/AppBundle/Resources/views/Org/ClientProfile/overview.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/overview.html.twig
@@ -24,6 +24,10 @@
 
     <p class="bold">{{ 'courtOrderNo' | trans({}, 'client-profile') }} {{ client.caseNumber }}</p>
 
+    {% include 'AppBundle:Org/ClientProfile:_client.html.twig' with {
+    '   client': client
+    } %}
+
     <div class="panel panel-admin hard">
         <div class="panel-heading">
           {% if report.isUnsubmitted %}
@@ -68,10 +72,6 @@
     {% include 'AppBundle:Org/ClientProfile:_reports.html.twig' with {
         'reports': client.submittedReports,
 			  'client': client
-    } %}
-
-    {% include 'AppBundle:Org/ClientProfile:_client.html.twig' with {
-    '   client': client
     } %}
 
 {% endblock %}

--- a/src/AppBundle/Resources/views/Org/Index/dashboard.html.twig
+++ b/src/AppBundle/Resources/views/Org/Index/dashboard.html.twig
@@ -98,7 +98,11 @@
                     {% elseif report.status.status == 'notFinished' %}
                         <span class="status status-large incomplete">{{ 'notFinished' | trans({}, 'common') }}</span>
                     {% elseif report.status.status == 'readyToSubmit' %}
-                        <span class="status status-large {{ report.unSubmitDate ? 'incomplete' : 'done' }}">{{ 'readyToSubmit' | trans({}, 'common') }}</span>
+                        {% if report.submitted == false %}
+                            <span class="status status-large changesNeeded">{{ 'changesNeeded' | trans({}, 'common') }}</span>
+                        {% else  %}
+                            <span class="status status-large done'}}">{{ 'readyToSubmit' | trans({}, 'common') }}</span>
+                        {% endif %}
                     {% endif %}
                 </td>
             </tr>

--- a/src/AppBundle/Resources/views/Report/Formatted/_assets.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_assets.html.twig
@@ -1,14 +1,15 @@
+{% set translationDomain = "report-assets" %}
 {% if assets | length > 0 or report.noAssetToAdd == true %}
     <div class="section break-before" id="assets-section">
-        <h2 class="section-heading">Client's assets</h2>
+        <h2 class="section-heading">{{ 'form.clientAssets.label' | trans(transOptions, translationDomain) }}</h2>
 
         {% if report.assets | length == 0 %}
             <div class="box">
-                <h3 class="label question bold">Does the client have any assets?</h3>
+                <h3 class="label question bold">{{ 'form.doesClientHaveAssets.label' | trans(transOptions, translationDomain) }}</h3>
                 <table class="checkboxes labelvalue inline">
                     <tr>
                         <td class="value checkbox">X</td>
-                        <td class="label">My client has no assets</td>
+                        <td class="label">{{ 'form.doesClientHaveAssets.noAssets.label' | trans(transOptions, translationDomain) }}</td>
                     </tr>
                 </table>
             </div>

--- a/src/AppBundle/Resources/views/Report/Formatted/_debts.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_debts.html.twig
@@ -3,15 +3,15 @@
 {% trans_default_domain translationDomain %}
 
 <div class="section break-before" id="debts-section">
-    <h2 class="section-heading">Client's debts</h2>
+    <h2 class="section-heading">{{ 'form.clientsDebts.label' | trans(transOptions, translationDomain) }}</h2>
 
     {% if report.hasDebts == 'no' %}
         <div class="box">
-            <h3 class="label question bold">Does the client have any debts?</h3>
+            <h3 class="label question bold">{{ 'form.doesClientHaveDebts.label' | trans(transOptions, translationDomain) }}</h3>
             <table class="checkboxes labelvalue inline">
                 <tr>
                     <td class="value checkbox">X</td>
-                    <td class="label">My client has no debts</td>
+                    <td class="label">{{ 'form.doesClientHaveDebts.noDebts.label' | trans(transOptions, translationDomain) }}</td>
                 </tr>
             </table>
         </div>

--- a/src/AppBundle/Resources/views/Report/Formatted/_visits_care.html.twig
+++ b/src/AppBundle/Resources/views/Report/Formatted/_visits_care.html.twig
@@ -1,20 +1,21 @@
+{% set translationDomain = "report-visits-care" %}
 {% import 'AppBundle:Macros:macros-review.html.twig' as macros %}
 
 <div class="section" id="safeguarding-section">
     <h2 class="section-heading">Visits and care</h2>
 
     {{ macros.answerYesNo({
-        question: 'Do you live with the client',
+        question: 'form.doYouLiveWithClient.label' | trans(transOptions, translationDomain),
         answer: visitsCare.doYouLiveWithClient,
         moreDetails: visitsCare.howOftenDoYouContactClient,
-        moreDetailsLabel: 'How often do you contact the client and how do you make sure others are looking after the client\'s needs if you can\'t ?',
+        moreDetailsLabel: 'form.howOftenDoYouContactClient.labelShort' | trans(transOptions, translationDomain),
         showMoreDetailsWith: 'no'
     }) }}
 
-    {{ macros.careArrangements(visitsCare) }}
+    {{ macros.careArrangements(visitsCare, transOptions, translationDomain) }}
 
     {{ macros.answerYesNo({
-        question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, 'report-visits-care'),
+        question: 'form.doesClientHaveACarePlan.label' | trans(transOptions, translationDomain),
         answer: visitsCare.doesClientHaveACarePlan,
         moreDetails: visitsCare.whenWasCarePlanLastReviewed | date("m / Y"),
         moreDetailsLabel: 'Review date',

--- a/src/AppBundle/Resources/views/Report/Report/_header.html.twig
+++ b/src/AppBundle/Resources/views/Report/Report/_header.html.twig
@@ -11,7 +11,11 @@
 
 {% if reportStatus.isReadyToSubmit and report.isDue %}
     <div id="header-report-submit" class="hero behat-region-report-ready-banner">
-        <h2 class="heading-large flush--ends">{{ 'reportIsReady' | trans() }}</h2>
+        {% if report.submitted == false %}
+            <h2 class="status status-large changesNeeded">{{ 'changesNeeded' | trans({}, 'common') }}</h2>
+        {% else %}
+            <h2 class="heading-large flush--ends">{{ 'reportIsReady' | trans() }}</h2>
+        {% endif %}
         <a class="button push-half--top behat-link-report-submit" href="{{ path('report_review', {'reportId': report.id}) }}">{{ 'continue' | trans({}, 'common') }}</a>
     </div>
 {% endif %}

--- a/src/AppBundle/Resources/views/Report/Report/overview.html.twig
+++ b/src/AppBundle/Resources/views/Report/Report/overview.html.twig
@@ -25,7 +25,6 @@
                 <li>{{ 'reportingPeriod' | trans() }}:
                     <span class="bold-small">{{ report.startDate | date("j F Y") }} to {{ report.endDate | date("j F Y") }}</span>
                 </li>
-                {# @biggs to style #}
                 <li class="{{ report.unSubmitDate ? 'orangeWarning' : '' }}">{{ 'dueDate' | trans() }}:
                     <span class="bold-small">{{ report.dueDate | date("j F Y") }}</span>
                 </li>

--- a/tests/behat/features/deputy/04-user/04-user-edit.feature
+++ b/tests/behat/features/deputy/04-user/04-user-edit.feature
@@ -1,5 +1,5 @@
 Feature: deputy / report / edit user
-    
+
     @deputy
     Scenario: edit user details
         Given I load the application status from "report-submit-pre"
@@ -48,8 +48,32 @@ Feature: deputy / report / edit user
         And I should be on "/deputyship-details/your-details"
         And I should see "Paul Jamie" in the "profile-name" region
         And I should see "SW1H 9AA" in the "profile-address" region
-     
-  
+
+    # @deputy
+    # Scenario: Notification email sent for lay deputy changes
+    #     Given emails are sent from "deputy" area
+    #     And I reset the email log
+    #     And I am logged in as "laydeputy@publicguardian.gov.uk" with password "Abcd1234"
+    #     And I click on "user-account, profile-show, profile-edit"
+    #     When I fill in the following:
+    #        | profile_firstname | Maruxita |
+    #        | profile_lastname | Alvarez |
+    #        | profile_address1 | 1 Scotland Street |
+    #        | profile_address2 | Edinburgh |
+    #        | profile_address3 | Midlothian |
+    #        | profile_addressPostcode | EH1 1AA |
+    #        | profile_addressCountry | NL |
+    #        | profile_phoneMain | 0131 111 1111 |
+    #        | profile_phoneAlternative | 0131 222 2222 |
+    #     And I press "profile_save"
+    #     Then I should be on "/deputyship-details/your-details"
+    #     And the last email should have been sent to "digideps+update-contact@digital.justice.gov.uk"
+    #     And the last email should contain "The contact details of the following deputy have been updated:"
+    #     And the last email should contain "Maruxita Alvarez"
+    #     And the last email should contain "1 Scotland Street"
+    #     And the last email should contain "Netherlands"
+    #     And the last email should contain "0131 111 1111"
+
     @deputy
     Scenario: change user password
         Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
@@ -67,7 +91,7 @@ Feature: deputy / report / edit user
           | change_password_plain_password_second | 2 |
         And I press "change_password_save"
         Then the following fields should have an error:
-              | change_password_plain_password_first |      
+              | change_password_plain_password_first |
         # unmatching new passwords
         When I fill in the following:
           | change_password_current_password | Abcd1234 |

--- a/tests/behat/features/deputy/04-user/05-client-edit.feature
+++ b/tests/behat/features/deputy/04-user/05-client-edit.feature
@@ -57,4 +57,27 @@ Feature: deputy / report / edit client
         When I click on "client-edit"
         Then the following fields should have the corresponding values:
             | client_firstname | Nolan |
-        
+
+    # @deputy
+    # Scenario: edit client details
+    #     Given emails are sent from "deputy" area
+    #     And I reset the email log
+    #     And I am logged in as "laydeputy@publicguardian.gov.uk" with password "Abcd1234"
+    #     And I click on "user-account, client-show, client-edit"
+    #     When I fill in the following:
+    #         | client_firstname | Ulrich |
+    #         | client_lastname | Wentz |
+    #         | client_address |  17 South Parade |
+    #         | client_address2 | Second Floor |
+    #         | client_county | Nottingham |
+    #         | client_postcode | NG1 2HT |
+    #         | client_country | VE |
+    #         | client_phone | 0987654321 |
+    #     And I press "client_save"
+    #     Then I should be on "/deputyship-details/your-client"
+    #     And the last email should have been sent to "digideps+update-contact@digital.justice.gov.uk"
+    #     And the last email should contain "The contact details of the following client have been updated:"
+    #     And the last email should contain "Ulrich Wentz"
+    #     And the last email should contain "17 South Parade"
+    #     And the last email should contain "Venezuela"
+    #     And the last email should contain "0987654321"

--- a/tests/behat/features/pa/04-dashboard-client-profile/13-settings.feature
+++ b/tests/behat/features/pa/04-dashboard-client-profile/13-settings.feature
@@ -57,6 +57,15 @@ Feature: PA settings
     And I should see "Solicitor Assistant" in the "profile-job" region
     And I should see "10000000012" in the "profile-phone" region
 
+  Scenario: Notification email not sent for PA deputy changes
+    Given emails are sent from "deputy" area
+    And I reset the email log
+    And I am logged in as "behat-pa-user@publicguardian.gov.uk" with password "Abcd1234"
+    And I click on "org-settings, profile-show, profile-edit"
+    When I press "profile_save"
+    Then I should be on "/org/settings/your-details"
+    And no email should have been sent
+
   Scenario: PA Admin logs in and updates profile and removes admin
     Given I am logged in as "behat-pa1-admin@publicguardian.gov.uk" with password "Abcd1234"
     When I click on "org-settings, profile-show, profile-edit"

--- a/tests/behat/features/prof/04-dashboard-client-profile/13-settings.feature
+++ b/tests/behat/features/prof/04-dashboard-client-profile/13-settings.feature
@@ -40,6 +40,15 @@ Feature: PROF settings
     And I should see "AB1 2CD" in the "profile-address" region
     And I should see "United Kingdom" in the "profile-address" region
 
+  Scenario: Notification email not sent for professional deputy changes
+    Given emails are sent from "deputy" area
+    And I reset the email log
+    And I am logged in as "behat-prof-user@publicguardian.gov.uk" with password "Abcd1234"
+    And I click on "org-settings, profile-show, profile-edit"
+    When I press "profile_save"
+    Then I should be on "/org/settings/your-details"
+    And no email should have been sent
+
   Scenario: PROF Admin logs in and updates profile and sees removeAdmin field but does not
     Given I am logged in as "behat-prof1-admin@publicguardian.gov.uk" with password "Abcd1234"
     When I click on "org-settings, profile-show, profile-edit"


### PR DESCRIPTION
I also updated the report overview page with the same Changes Needed text as it was conflicting with the dashboard status and would have been confusing for users.