### PR TITLE
DDPB-2535 Move client details for prof to top of client overview

### DIFF
--- a/src/AppBundle/Resources/views/Org/ClientProfile/overview.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/overview.html.twig
@@ -24,6 +24,10 @@
 
     <p class="bold">{{ 'courtOrderNo' | trans({}, 'client-profile') }} {{ client.caseNumber }}</p>
 
+    {% include 'AppBundle:Org/ClientProfile:_client.html.twig' with {
+    '   client': client
+    } %}
+
     <div class="panel panel-admin hard">
         <div class="panel-heading">
           {% if report.isUnsubmitted %}
@@ -68,10 +72,6 @@
     {% include 'AppBundle:Org/ClientProfile:_reports.html.twig' with {
         'reports': client.submittedReports,
 			  'client': client
-    } %}
-
-    {% include 'AppBundle:Org/ClientProfile:_client.html.twig' with {
-    '   client': client
     } %}
 
 {% endblock %}


### PR DESCRIPTION
So that they can see the client details easily when choosing a
client from the dashboard.