### PR TITLE
DDPB-2553: Add a closing balance in Accounts section

### DIFF
--- a/src/AppBundle/Resources/translations/ndr-bank-accounts.en.yml
+++ b/src/AppBundle/Resources/translations/ndr-bank-accounts.en.yml
@@ -27,7 +27,9 @@ startPage:
 
 stepPage:
   htmlTitle: "Deputy report - Accounts | GOV.UK"
-  pageTitle: Add an account
+  pageTitle:
+    add: Add an account
+    edit: Edit an account
   supportTitle: Accounts
   pageSectionDescription:
     step1: Start by selecting one type of account. We'll then ask you for the details of that account. You can go back and add more accounts if you need to.

--- a/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
+++ b/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
@@ -17,7 +17,9 @@ startPage:
 
 stepPage:
   htmlTitle: "Deputy report - Accounts | GOV.UK"
-  pageTitle: Add an account
+  pageTitle:
+    add: Add an account
+    edit: Edit an account
   supportTitle: Accounts
   pageSectionDescription:
     step1: Start by selecting one type of account. We'll then ask you for the details of that account. You can go back and add more accounts if you need to.

--- a/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
+++ b/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
@@ -42,7 +42,8 @@ summaryPage:
     In this section, we ask you about %client%'s bank accounts, building society accounts,
     savings accounts and ISAs.
   totalBalance: "Total balance on %endDate%: £%amount%"
-  balanceRequired: Balance for %date% required, <a href="%link%">add balance</a>.
+  balanceRequired: Balance for %date% required
+  addBalance: Add balance
 
 deletePage:
   htmlTitle: "Deputy report - Accounts | GOV.UK"

--- a/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
+++ b/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
@@ -42,8 +42,7 @@ summaryPage:
     In this section, we ask you about %client%'s bank accounts, building society accounts,
     savings accounts and ISAs.
   totalBalance: "Total balance on %endDate%: £%amount%"
-  balanceRequired: Balance for %date% required
-  addBalance: Add balance
+  balanceRequired: Balance for %date% required, <a href="%link%">add balance</a>.
 
 deletePage:
   htmlTitle: "Deputy report - Accounts | GOV.UK"

--- a/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
+++ b/src/AppBundle/Resources/translations/report-bank-accounts.en.yml
@@ -42,6 +42,8 @@ summaryPage:
     In this section, we ask you about %client%'s bank accounts, building society accounts,
     savings accounts and ISAs.
   totalBalance: "Total balance on %endDate%: £%amount%"
+  balanceRequired: Balance for %date% required
+  addBalance: Add balance
 
 deletePage:
   htmlTitle: "Deputy report - Accounts | GOV.UK"

--- a/src/AppBundle/Resources/views/Ndr/BankAccount/step.html.twig
+++ b/src/AppBundle/Resources/views/Ndr/BankAccount/step.html.twig
@@ -7,7 +7,7 @@
 {% set transOptions = {'%client%': ndr.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans(transOptions) }}{% endblock %}
-{% block pageTitle %}{{ 'stepPage.pageTitle' | trans(transOptions) }}{% endblock %}
+{% block pageTitle %}{{ ('stepPage.pageTitle.' ~ (account.id ? 'edit' : 'add')) | trans(transOptions) }}{% endblock %}
 {% block pageTitleClass %}heading-large{% endblock %}
 
 {% block supportTitleTop %}

--- a/src/AppBundle/Resources/views/Report/BankAccount/_list.html.twig
+++ b/src/AppBundle/Resources/views/Report/BankAccount/_list.html.twig
@@ -47,8 +47,11 @@
             </td>
             {% if account.closingBalance == null %}
                 <td class="numeric-small">
-                    £-,-
-                    <span class="error-message">{{ 'pleaseAnswer' | trans({}, 'common' ) }}</span>
+                    {{ 'summaryPage.balanceRequired' | trans({ '%date%': report.endDate | date("j F Y") }) }}
+                    <br>
+                    <a href="{{ path('bank_accounts_step' , {'reportId': report.id, 'step': 3, 'accountId': account.id}) }}">
+                        {{ 'summaryPage.addBalance' | trans }}
+                    </a>
                 </td>
             {% else %}
                 <td class="numeric-small">

--- a/src/AppBundle/Resources/views/Report/BankAccount/_list.html.twig
+++ b/src/AppBundle/Resources/views/Report/BankAccount/_list.html.twig
@@ -48,11 +48,11 @@
             {% if account.closingBalance == null %}
                 <td class="numeric-small">
                     <div class="error-message">
-                        {{ 'summaryPage.balanceRequired' | trans({
-                            '%date%': report.endDate | date("j F Y"),
-                            '%link%': path('bank_accounts_step' , {'reportId': report.id, 'step': 3, 'accountId': account.id})
-                        }) | raw }}
+                        {{ 'summaryPage.balanceRequired' | trans({ '%date%': report.endDate | date("j F Y") }) }}
                     </div>
+                    <a class="change-answer" href="{{ path('bank_accounts_step' , {'reportId': report.id, 'step': 3, 'accountId': account.id}) }}">
+                        {{ 'summaryPage.addBalance' | trans }}
+                    </a>
                 </td>
             {% else %}
                 <td class="numeric-small">

--- a/src/AppBundle/Resources/views/Report/BankAccount/_list.html.twig
+++ b/src/AppBundle/Resources/views/Report/BankAccount/_list.html.twig
@@ -47,11 +47,12 @@
             </td>
             {% if account.closingBalance == null %}
                 <td class="numeric-small">
-                    {{ 'summaryPage.balanceRequired' | trans({ '%date%': report.endDate | date("j F Y") }) }}
-                    <br>
-                    <a href="{{ path('bank_accounts_step' , {'reportId': report.id, 'step': 3, 'accountId': account.id}) }}">
-                        {{ 'summaryPage.addBalance' | trans }}
-                    </a>
+                    <div class="error-message">
+                        {{ 'summaryPage.balanceRequired' | trans({
+                            '%date%': report.endDate | date("j F Y"),
+                            '%link%': path('bank_accounts_step' , {'reportId': report.id, 'step': 3, 'accountId': account.id})
+                        }) | raw }}
+                    </div>
                 </td>
             {% else %}
                 <td class="numeric-small">

--- a/src/AppBundle/Resources/views/Report/BankAccount/step.html.twig
+++ b/src/AppBundle/Resources/views/Report/BankAccount/step.html.twig
@@ -7,7 +7,7 @@
 {% set transOptions = {'%client%': report.client.firstname | e } %}
 
 {% block htmlTitle %}{{ 'stepPage.htmlTitle' | trans(transOptions) }}{% endblock %}
-{% block pageTitle %}{{ 'stepPage.pageTitle' | trans(transOptions) }}{% endblock %}
+{% block pageTitle %}{{ ('stepPage.pageTitle.' ~ (account.id ? 'edit' : 'add')) | trans(transOptions) }}{% endblock %}
 {% block pageTitleClass %}heading-large{% endblock %}
 
 {% block supportTitleTop %}

--- a/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -160,6 +160,7 @@ Feature: Report submit
             | HSBC - saving account | account-02ca |
             | Saving account        | account-02ca |
             | 445566                | account-02ca |
+            | Balance for 31 December 2017 required | account-02ca |
 
     @deputy
     Scenario: assert report is not editable after submission


### PR DESCRIPTION
Replaces the prompt on the accounts page of a second report to make it clearer when only the closing balance needs updating.

Also updates the page title on accounts section to reflect whether you're adding a new or editing an existing account.