### PR TITLE
DDPB-2524: Update tests to account for fixture user changes

### DIFF
--- a/tests/behat/features/admin/04-case-manager.feature
+++ b/tests/behat/features/admin/04-case-manager.feature
@@ -26,7 +26,7 @@ Feature: admin / case manager
     # assert client search and client page return 200
     When I should be on "/admin/client/search"
     Then the response status code should be 200
-    When I click on "client-detail-test1024"
+    When I click on "client-detail-102-4"
     Then the response status code should be 200
     # assert user and password edit work
     When I click on "user-account, profile-show, profile-edit, save"

--- a/tests/behat/features/deputy/02-ndr/10-submit.feature
+++ b/tests/behat/features/deputy/02-ndr/10-submit.feature
@@ -94,14 +94,14 @@ Feature: ndr / report submit
     @ndr
     Scenario: check NDR report not accessible after submission
         Given I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "Abcd1234"
-        And the URL "/ndr/5/visits-care/summary" should not be accessible
-        And the URL "/ndr/5/deputy-expenses/summary" should not be accessible
-        And the URL "/ndr/5/income-benefits/summary" should not be accessible
-        And the URL "/ndr/5/bank-accounts/summary" should not be accessible
-        And the URL "/ndr/5/assets/summary" should not be accessible
-        And the URL "/ndr/5/debts/summary" should not be accessible
-        And the URL "/ndr/5/actions/summary" should not be accessible
-        And the URL "/ndr/5/any-other-info/summary" should not be accessible
+        And the URL "/ndr/11/visits-care/summary" should not be accessible
+        And the URL "/ndr/11/deputy-expenses/summary" should not be accessible
+        And the URL "/ndr/11/income-benefits/summary" should not be accessible
+        And the URL "/ndr/11/bank-accounts/summary" should not be accessible
+        And the URL "/ndr/11/assets/summary" should not be accessible
+        And the URL "/ndr/11/debts/summary" should not be accessible
+        And the URL "/ndr/11/actions/summary" should not be accessible
+        And the URL "/ndr/11/any-other-info/summary" should not be accessible
 
     @ndr
     Scenario: NDR homepage and create new report

--- a/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -20,13 +20,13 @@ Feature: Report submit
         And I save the application status into "report-submit-pre"
         And I click on "report-start"
         # assert I cannot access the submitted page directly
-        And the URL "/report/5/submitted" should not be accessible
+        And the URL "/report/11/submitted" should not be accessible
         # assert I cannot access the submit page from declaration page
-        When I go to "/report/5/declaration"
-        Then the URL "/report/5/submitted" should not be accessible
+        When I go to "/report/11/declaration"
+        Then the URL "/report/11/submitted" should not be accessible
         And I click on "reports, report-start"
         # submit without ticking "agree"
-        When I go to "/report/5/declaration"
+        When I go to "/report/11/declaration"
         And I press "report_declaration_save"
         #
         # empty form
@@ -165,19 +165,19 @@ Feature: Report submit
     @deputy
     Scenario: assert report is not editable after submission
         Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
-        Then the URL "/report/5/overview" should not be accessible
-        And the URL "/report/5/decisions/summary" should not be accessible
-        And the URL "/report/5/contacts/summary" should not be accessible
-        And the URL "/report/5/visits-care/summary" should not be accessible
-        And the URL "/report/5/bank-accounts/summary" should not be accessible
-        And the URL "/report/5/money-transfers/summary" should not be accessible
-        And the URL "/report/5/money-in/summary" should not be accessible
-        And the URL "/report/5/money-out/summary" should not be accessible
-        And the URL "/report/5/balance" should not be accessible
-        And the URL "/report/5/assets/summary" should not be accessible
-        And the URL "/report/5/debts/summary" should not be accessible
-        And the URL "/report/5/actions" should not be accessible
-        And the URL "/report/5/declaration" should not be accessible
+        Then the URL "/report/11/overview" should not be accessible
+        And the URL "/report/11/decisions/summary" should not be accessible
+        And the URL "/report/11/contacts/summary" should not be accessible
+        And the URL "/report/11/visits-care/summary" should not be accessible
+        And the URL "/report/11/bank-accounts/summary" should not be accessible
+        And the URL "/report/11/money-transfers/summary" should not be accessible
+        And the URL "/report/11/money-in/summary" should not be accessible
+        And the URL "/report/11/money-out/summary" should not be accessible
+        And the URL "/report/11/balance" should not be accessible
+        And the URL "/report/11/assets/summary" should not be accessible
+        And the URL "/report/11/debts/summary" should not be accessible
+        And the URL "/report/11/actions" should not be accessible
+        And the URL "/report/11/declaration" should not be accessible
 
     @deputy
     Scenario: deputy report download

--- a/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -6,8 +6,6 @@ Feature: Admin unsubmit report (from client page)
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "admin-client-search"
     Then each text should be present in the corresponding region:
-      | 12 clients | client-search-count |
-    Then each text should be present in the corresponding region:
       | Cly Hent | client-behat001 |
     When I fill in the following:
       | search_clients_q | hent |

--- a/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -6,8 +6,6 @@ Feature: Admin report checklist
     # Navigate to checklist via search
     And I click on "admin-client-search"
     Then each text should be present in the corresponding region:
-      | 12 clients | client-search-count |
-    Then each text should be present in the corresponding region:
       | Cly Hent | client-behat001 |
     When I fill in the following:
       | search_clients_q | hent |

--- a/tests/behat/features/deputy/05-acl/02-pages-security.feature
+++ b/tests/behat/features/deputy/05-acl/02-pages-security.feature
@@ -40,38 +40,38 @@ Feature: deputy / acl / security on pages
     Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
     And I save the application status into "deputy-acl-before"
     Then the following "client" pages should return the following status:
-      | /report/5/overview         | 200 |
+      | /report/11/overview         | 200 |
       # decisions
-      | /report/5/decisions        | 200 |
+      | /report/11/decisions        | 200 |
       # contacts
-      | /report/5/contacts         | 200 |
-      | /report/5/contacts/add     | 200 |
+      | /report/11/contacts         | 200 |
+      | /report/11/contacts/add     | 200 |
       # assets
-      | /report/5/assets           | 200 |
-      | /report/5/assets/step-type | 200 |
+      | /report/11/assets           | 200 |
+      | /report/11/assets/step-type | 200 |
       # accounts
-      | /report/5/bank-accounts    | 200 |
+      | /report/11/bank-accounts    | 200 |
     # behat-malicious CANNOT access the same URLs
     Given I am logged in as "behat-malicious@publicguardian.gov.uk" with password "Abcd1234"
     # reload the status (as some URLs calls might have deleted data)
     And I load the application status from "deputy-acl-before"
     Then the following "client" pages should return the following status:
-      | /report/6/overview                | 200 |
-      | /report/5/overview                | 500 |
+      | /report/12/overview                | 200 |
+      | /report/11/overview                | 500 |
       # decisions
-      | /report/6/decisions               | 200 |
-      | /report/5/decisions               | 500 |
+      | /report/12/decisions               | 200 |
+      | /report/11/decisions               | 500 |
       # contacts
-      | /report/6/contacts                | 200 |
-      | /report/5/contacts                | 500 |
+      | /report/12/contacts                | 200 |
+      | /report/11/contacts                | 500 |
       # assets
-      | /report/6/assets                  | 200 |
-      | /report/5/assets                  | 500 |
+      | /report/12/assets                  | 200 |
+      | /report/11/assets                  | 500 |
       # accounts
-      | /report/5/bank-accounts           | 500 |
+      | /report/11/bank-accounts           | 500 |
       # submit
-      | /report/5/declaration             | 500 |
-      | /report/5/submitted               | 500 |
+      | /report/11/declaration             | 500 |
+      | /report/11/submitted               | 500 |
     And I load the application status from "deputy-acl-before"
 
-    
+

--- a/tests/behat/features/pa/04-dashboard-client-profile/13-settings.feature
+++ b/tests/behat/features/pa/04-dashboard-client-profile/13-settings.feature
@@ -60,7 +60,7 @@ Feature: PA settings
   Scenario: Notification email not sent for PA deputy changes
     Given emails are sent from "deputy" area
     And I reset the email log
-    And I am logged in as "behat-pa-user@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-pa-admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "org-settings, profile-show, profile-edit"
     When I press "profile_save"
     Then I should be on "/org/settings/your-details"

--- a/tests/behat/features/prof/04-dashboard-client-profile/13-settings.feature
+++ b/tests/behat/features/prof/04-dashboard-client-profile/13-settings.feature
@@ -29,7 +29,7 @@ Feature: PROF settings
       | profile_phoneMain  | 10000000011                           |
       | profile_address1         | 123 Streetname |
       | profile_addressPostcode  | AB1 2CD        |
-      | profile_addressCountry   | GB             |
+        | profile_addressCountry   | GB             |
     And I press "profile_save"
     Then the form should be valid
     Then I should see "John Named Chap Greenish" in the "profile-name" region
@@ -43,7 +43,7 @@ Feature: PROF settings
   Scenario: Notification email not sent for professional deputy changes
     Given emails are sent from "deputy" area
     And I reset the email log
-    And I am logged in as "behat-prof-user@publicguardian.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-prof-admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "org-settings, profile-show, profile-edit"
     When I press "profile_save"
     Then I should be on "/org/settings/your-details"


### PR DESCRIPTION
Fixes tests which have dependencies on fixtures which have changed:
- Removing unnecessary magic number tests
- Updating magic numbers in other tests
- Updating references to changed fixture data (e.g. login email addresses)