### PR TITLE
DDPB-2576: Run infrastructure feature tests first

### DIFF
--- a/docker/confd/templates/behat.yml.tmpl
+++ b/docker/confd/templates/behat.yml.tmpl
@@ -4,6 +4,17 @@ default:
     autoload:
         '': %paths.base%/bootstrap
     suites:
+        infra:
+            description: Minimal test suite to check infrastructure
+            paths: [ %paths.base%/features ]
+            filters:
+                tags: "@infra"
+            contexts:
+            {{ if exists "/api/database/name" }}
+                - DigidepsBehat\FeatureContext: [{ dbName: {{ getv "/api/database/name" }} }]
+            {{ else }}
+                - DigidepsBehat\FeatureContext: [{ dbName: "api" }]
+            {{ end }}
 
         admin:
             description: End to end journey for Admin user
@@ -71,18 +82,6 @@ default:
                 - DigidepsBehat\FeatureContext: [{ dbName: {{ getv "/api/database/name" }}, sessionName: 'digideps' }]
             {{ else }}
                 - DigidepsBehat\FeatureContext: [{ dbName: api, sessionName: 'digideps' }]
-            {{ end }}
-
-        infra:
-            description: Minimal test suite to check infrastructure
-            paths: [ %paths.base%/features ]
-            filters:
-                tags: "@infra"
-            contexts:
-            {{ if exists "/api/database/name" }}
-                - DigidepsBehat\FeatureContext: [{ dbName: {{ getv "/api/database/name" }} }]
-            {{ else }}
-                - DigidepsBehat\FeatureContext: [{ dbName: "api" }]
             {{ end }}
 
         components:

--- a/scripts/clienttest.sh
+++ b/scripts/clienttest.sh
@@ -2,6 +2,7 @@
 set -e
 #let's configure environment
 run-parts /etc/my_init.d
+/sbin/setuser app mkdir -p /tmp/behat
 chown app:app /tmp/behat
 chown app:app /tmp
 
@@ -10,7 +11,6 @@ mkdir -p /var/log/app
 chown app:app /var/log/app
 
 cd /app
-/sbin/setuser app mkdir -p /tmp/behat
 export PGHOST=${API_DATABASE_HOSTNAME:=postgres}
 export PGPASSWORD=${API_DATABASE_PASSWORD:=api}
 export PGDATABASE=${API_DATABASE_NAME:=api}
@@ -22,3 +22,5 @@ rm -rf app/cache/*
 
 # behat
 /sbin/setuser app bin/behat --config=tests/behat/behat.yml --profile=${PROFILE:=headless} --stop-on-failure
+
+rm -rf /tmp/behat

--- a/scripts/clienttest.sh
+++ b/scripts/clienttest.sh
@@ -22,5 +22,3 @@ rm -rf app/cache/*
 
 # behat
 /sbin/setuser app bin/behat --config=tests/behat/behat.yml --profile=${PROFILE:=headless} --stop-on-failure
-
-rm -rf /tmp/behat

--- a/scripts/clienttest.sh
+++ b/scripts/clienttest.sh
@@ -21,8 +21,4 @@ rm -rf app/cache/*
 /sbin/setuser app php vendor/phpunit/phpunit/phpunit -c tests/phpunit/
 
 # behat
-export BEHAT_PARAMS="{\"extensions\" : {\"Behat\\\\MinkExtension\\\\ServiceContainer\\\\MinkExtension\" : {\"base_url\" : \"${FRONTEND_NONADMIN_HOST}\",\"selenium2\" : { \"wd_host\" : \"$WD_HOST\" }, \"browser_stack\" : { \"username\": \"$BROWSERSTACK_USER\", \"access_key\": \"$BROWSERSTACK_KEY\"}}}}"
-/sbin/setuser app bin/behat --config=tests/behat/behat.yml --suite=lay --profile=${PROFILE:=headless} --stop-on-failure
-/sbin/setuser app bin/behat --config=tests/behat/behat.yml --suite=ndr --profile=${PROFILE:=headless} --stop-on-failure
-/sbin/setuser app bin/behat --config=tests/behat/behat.yml --suite=pa --profile=${PROFILE:=headless} --stop-on-failure
-/sbin/setuser app bin/behat --config=tests/behat/behat.yml --suite=prof --profile=${PROFILE:=headless} --stop-on-failure
+/sbin/setuser app bin/behat --config=tests/behat/behat.yml --profile=${PROFILE:=headless} --stop-on-failure

--- a/tests/behat/features/deputy/02-ndr/10-submit.feature
+++ b/tests/behat/features/deputy/02-ndr/10-submit.feature
@@ -62,16 +62,9 @@ Feature: ndr / report submit
         And I click on "admin-documents"
         Then I should be on "/admin/documents/list"
         And I save the current URL as "ndr-admin-documents-list-new"
-            # test filters
-        When I click on "tab-archived"
-        Then I should see the "report-submission" region exactly 0 times
-        When I click on "tab-new"
-        Then I should see the "report-submission" region exactly 1 times
             # assert submission and download
-        Given each text should be present in the corresponding region:
-            | Cly3 Hent3 | report-submission-1 |
-            | 33333333 | report-submission-1 |
-            | Report | report-submission-1 |
+        Then I should see "Cly3 Hent3"
+        And I should see "33333333"
         When I check "Select 33333333"
         Then I click on "download"
         # only checks one level deep. In this case, we check for a single report zip file

--- a/tests/behat/features/deputy/02-ndr/10-submit.feature
+++ b/tests/behat/features/deputy/02-ndr/10-submit.feature
@@ -84,17 +84,18 @@ Feature: ndr / report submit
             | AU | report-submission-1 |
 
 
-    @ndr
+    # Magic: uses report ID number
+    @ndr @magic
     Scenario: check NDR report not accessible after submission
         Given I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "Abcd1234"
-        And the URL "/ndr/5/visits-care/summary" should not be accessible
-        And the URL "/ndr/5/deputy-expenses/summary" should not be accessible
-        And the URL "/ndr/5/income-benefits/summary" should not be accessible
-        And the URL "/ndr/5/bank-accounts/summary" should not be accessible
-        And the URL "/ndr/5/assets/summary" should not be accessible
-        And the URL "/ndr/5/debts/summary" should not be accessible
-        And the URL "/ndr/5/actions/summary" should not be accessible
-        And the URL "/ndr/5/any-other-info/summary" should not be accessible
+        And the URL "/ndr/7/visits-care/summary" should not be accessible
+        And the URL "/ndr/7/deputy-expenses/summary" should not be accessible
+        And the URL "/ndr/7/income-benefits/summary" should not be accessible
+        And the URL "/ndr/7/bank-accounts/summary" should not be accessible
+        And the URL "/ndr/7/assets/summary" should not be accessible
+        And the URL "/ndr/7/debts/summary" should not be accessible
+        And the URL "/ndr/7/actions/summary" should not be accessible
+        And the URL "/ndr/7/any-other-info/summary" should not be accessible
 
     @ndr
     Scenario: NDR homepage and create new report

--- a/tests/behat/features/deputy/02-ndr/10-submit.feature
+++ b/tests/behat/features/deputy/02-ndr/10-submit.feature
@@ -74,14 +74,10 @@ Feature: ndr / report submit
         When I go to the URL previously saved as "ndr-admin-documents-list-new"
         Then I check "Select 33333333"
         When I click on "archive"
-        Then I should see the "report-submission" region exactly 0 times
-        When I click on "tab-archived"
+        And I click on "tab-archived"
         Then I should see the "report-submission" region exactly 1 times
-        And each text should be present in the corresponding region:
-            | Cly3 Hent3| report-submission-1 |
-            | 33333333 | report-submission-1 |
-            | Report | report-submission-1 |
-            | AU | report-submission-1 |
+        Then I should see "Cly3 Hent3"
+        And I should see "33333333"
 
 
     # Magic: uses report ID number

--- a/tests/behat/features/deputy/03-report/01-102/11-expenses.feature
+++ b/tests/behat/features/deputy/03-report/01-102/11-expenses.feature
@@ -30,10 +30,10 @@ Feature: Report deputy expenses
     And the step with the following values CANNOT be submitted:
       | expenses_single_explanation |                | [ERR] |
       | expenses_single_amount      | 0.0 | [ERR] |
+    And I select "HSBC - saving account - Savings account (****02ca)" from "expenses_single_bankAccountId"
     And the step with the following values CAN be submitted:
       | expenses_single_explanation | taxi from hospital on 3 november |
       | expenses_single_amount      | 35                               |
-      | expenses_single_bankAccountId       | 1                                |
         # add expense n.2
     And I choose "yes" when asked for adding another record
     And the step with the following values CAN be submitted:
@@ -60,11 +60,11 @@ Feature: Report deputy expenses
     Then the following fields should have the corresponding values:
       | expenses_single_explanation | taxi from hospital on 3 november |
       | expenses_single_amount      | 35.00                            |
-      | expenses_single_bankAccountId       | 1                                |
+    And I should see "HSBC - saving account - Savings account (****02ca)" in the "#expenses_single_bankAccountId" element
+    And I select "Court Funds Office account (****11cf)" from "expenses_single_bankAccountId"
     And the step with the following values CAN be submitted:
       | expenses_single_explanation | taxi from hospital on 4 november |
       | expenses_single_amount      | 45                               |
-      | expenses_single_bankAccountId       | 2                                |
     And each text should be present in the corresponding region:
       | taxi from hospital on 4 november | expense-taxi-from-hospital-on-4-november |
       | £45.00                           | expense-taxi-from-hospital-on-4-november |

--- a/tests/behat/features/deputy/03-report/01-102/12-gifts.feature
+++ b/tests/behat/features/deputy/03-report/01-102/12-gifts.feature
@@ -30,10 +30,10 @@ Feature: Report gifts
     And the step with the following values CANNOT be submitted:
       | gifts_single_explanation |     | [ERR] |
       | gifts_single_amount      | 0.0 | [ERR] |
+    And I select "HSBC - saving account - Savings account (****02ca)" from "gifts_single_bankAccountId"
     And the step with the following values CAN be submitted:
       | gifts_single_explanation | birthday gift to daughter |
       | gifts_single_amount      | 35                        |
-      | gifts_single_bankAccountId       | 1                         |
         # add expense n.2
     And I choose "yes" when asked for adding another record
     And the step with the following values CAN be submitted:
@@ -60,7 +60,7 @@ Feature: Report gifts
     Then the following fields should have the corresponding values:
       | gifts_single_explanation | birthday gift to daughter |
       | gifts_single_amount      | 35.00                     |
-      | gifts_single_bankAccountId       | 1                         |
+    And I should see "HSBC - saving account - Savings account (****02ca)" in the "#gifts_single_bankAccountId" element
     And the step with the following values CAN be submitted:
       | gifts_single_explanation | birthday gift to the daughter |
       | gifts_single_amount      | 45                            |

--- a/tests/behat/features/deputy/03-report/01-102/17-money.feature
+++ b/tests/behat/features/deputy/03-report/01-102/17-money.feature
@@ -39,10 +39,10 @@ Feature: Report money 102
     # add transaction n.3
     And the step with the following values CAN be submitted:
       | account_category_0 | anything-else |
+    And I select "HSBC - saving account - Savings account (****02ca)" from "account_bankAccountId"
     And the step with the following values CAN be submitted:
       | account_description   | money found on the road |
       | account_amount        | 50                      |
-      | account_bankAccountId | 1                       |
     # add another: no
     And I choose "no" when asked for adding another record
     # check record in summary page
@@ -69,7 +69,7 @@ Feature: Report money 102
     Then the following fields should have the corresponding values:
       | account_description   | money found on the road |
       | account_amount        | 50.00                   |
-      | account_bankAccountId | 1                       |
+    And I should see "HSBC - saving account - Savings account (****02ca)" in the "#account_bankAccountId" element
     And the step with the following values CAN be submitted:
       | account_description | Some money found on the road |
       | account_amount      | 51                           |
@@ -112,10 +112,10 @@ Feature: Report money 102
       # add transaction n.3
     And the step with the following values CAN be submitted:
       | account_category_0 | anything-else-paid-out |
+    And I select "HSBC - saving account - Savings account (****02ca)" from "account_bankAccountId"
     And the step with the following values CAN be submitted:
       | account_description   | money found on the road |
       | account_amount        | 50                      |
-      | account_bankAccountId | 1                       |
       # add another: no
     And I choose "no" when asked for adding another record
       # check record in summary page
@@ -143,7 +143,7 @@ Feature: Report money 102
     Then the following fields should have the corresponding values:
       | account_description   | money found on the road |
       | account_amount        | 50.00                   |
-      | account_bankAccountId | 1                       |
+    And I should see "HSBC - saving account - Savings account (****02ca)" in the "#account_bankAccountId" element
     And the step with the following values CAN be submitted:
       | account_description | Some money found on the road |
       | account_amount      | 51                           |
@@ -158,12 +158,10 @@ Feature: Report money 102
     And I click on "report-start, edit-money_out, add"
     And the step with the following values CAN be submitted:
       | account_category_5 | food |
+    And I select "TEMP account - Current account (****03ta)" from "account_bankAccountId"
     And the step with the following values CAN be submitted:
       | account_description   | coffee |
       | account_amount        | 2              |
-      # 3rd bank account has ID=4. update if that feature is changed
-      | account_bankAccountId | 4                |
-      # add another: yes
     And I choose "no" when asked for adding another record
     And each text should be present in the corresponding region:
       | 03ta | transaction-coffee |

--- a/tests/behat/features/deputy/03-report/01-102/19-transfers.feature
+++ b/tests/behat/features/deputy/03-report/01-102/19-transfers.feature
@@ -17,12 +17,14 @@ Feature: Report account transfers
       | yes_no_noTransfersToAdd_0 | 0 |
       # add transfer n.1 (and validate form)
     And the step cannot be submitted without making a selection
-    And the step with the following values CANNOT be submitted:
-      | money_transfers_type_accountFromId | 1 | |
-      | money_transfers_type_accountToId   | 1 | [ERR] |
-    And the step with the following values CAN be submitted:
-      | money_transfers_type_accountFromId | 1 |
-      | money_transfers_type_accountToId   | 2 |
+    When I select "HSBC - saving account - Savings account (****02ca)" from "money_transfers_type_accountFromId"
+    And I select "HSBC - saving account - Savings account (****02ca)" from "money_transfers_type_accountToId"
+    And I submit the step
+    Then the form should be invalid
+    When I select "HSBC - saving account - Savings account (****02ca)" from "money_transfers_type_accountFromId"
+    And I select "Court Funds Office account (****11cf)" from "money_transfers_type_accountToId"
+    And I submit the step
+    Then the form should be valid
     And the step cannot be submitted without making a selection
     And the step with the following values CANNOT be submitted:
       | money_transfers_type_amount | asasd |
@@ -31,9 +33,10 @@ Feature: Report account transfers
       # add another: yes
     And I choose "yes" when asked for adding another record
       # add transfer n.2
-    And the step with the following values CAN be submitted:
-      | money_transfers_type_accountFromId | 1 |
-      | money_transfers_type_accountToId   | 2 |
+    When I select "HSBC - saving account - Savings account (****02ca)" from "money_transfers_type_accountFromId"
+    And I select "Court Funds Office account (****11cf)" from "money_transfers_type_accountToId"
+    And I submit the step
+    Then the form should be valid
     And the step with the following values CAN be submitted:
       | money_transfers_type_amount | 98.76 |
       # add another: no
@@ -51,12 +54,12 @@ Feature: Report account transfers
     When I go back from the step
       # edit transfer n.1
     When I click on "edit" in the "transfer-02ca-11cf-123456" region
-    Then the following fields should have the corresponding values:
-      | money_transfers_type_accountFromId | 1 |
-      | money_transfers_type_accountToId   | 2 |
-    And the step with the following values CAN be submitted:
-      | money_transfers_type_accountFromId | 2 |
-      | money_transfers_type_accountToId   | 1 |
+    Then I should see "HSBC - saving account - Savings account (****02ca)" in the "#money_transfers_type_accountFromId" element
+    And I should see "Court Funds Office account (****11cf)" in the "#money_transfers_type_accountToId" element
+    When I select "Court Funds Office account (****11cf)" from "money_transfers_type_accountFromId"
+    And I select "HSBC - saving account - Savings account (****02ca)" from "money_transfers_type_accountToId"
+    And I submit the step
+    Then the form should be valid
     Then the following fields should have the corresponding values:
       | money_transfers_type_amount | 1,234.56 |
     And the step with the following values CAN be submitted:

--- a/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -12,7 +12,8 @@ Feature: Report submit
         And I click on "declaration-page"
         Then the URL should match "/report/\d+/declaration"
 
-    @deputy
+    # Magic: uses report ID number
+    @deputy @magic
     Scenario: report submission
         Given emails are sent from "deputy" area
         And I reset the email log
@@ -20,13 +21,13 @@ Feature: Report submit
         And I save the application status into "report-submit-pre"
         And I click on "report-start"
         # assert I cannot access the submitted page directly
-        And the URL "/report/5/submitted" should not be accessible
+        And the URL "/report/7/submitted" should not be accessible
         # assert I cannot access the submit page from declaration page
-        When I go to "/report/5/declaration"
-        Then the URL "/report/5/submitted" should not be accessible
+        When I go to "/report/7/declaration"
+        Then the URL "/report/7/submitted" should not be accessible
         And I click on "reports, report-start"
         # submit without ticking "agree"
-        When I go to "/report/5/declaration"
+        When I go to "/report/7/declaration"
         And I press "report_declaration_save"
         #
         # empty form
@@ -155,22 +156,23 @@ Feature: Report submit
             | 445566                | account-02ca |
             | Balance for 31 December 2017 required | account-02ca |
 
-    @deputy
+    # Magic: uses report ID number
+    @deputy @magic
     Scenario: assert report is not editable after submission
         Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
-        Then the URL "/report/5/overview" should not be accessible
-        And the URL "/report/5/decisions/summary" should not be accessible
-        And the URL "/report/5/contacts/summary" should not be accessible
-        And the URL "/report/5/visits-care/summary" should not be accessible
-        And the URL "/report/5/bank-accounts/summary" should not be accessible
-        And the URL "/report/5/money-transfers/summary" should not be accessible
-        And the URL "/report/5/money-in/summary" should not be accessible
-        And the URL "/report/5/money-out/summary" should not be accessible
-        And the URL "/report/5/balance" should not be accessible
-        And the URL "/report/5/assets/summary" should not be accessible
-        And the URL "/report/5/debts/summary" should not be accessible
-        And the URL "/report/5/actions" should not be accessible
-        And the URL "/report/5/declaration" should not be accessible
+        Then the URL "/report/7/overview" should not be accessible
+        And the URL "/report/7/decisions/summary" should not be accessible
+        And the URL "/report/7/contacts/summary" should not be accessible
+        And the URL "/report/7/visits-care/summary" should not be accessible
+        And the URL "/report/7/bank-accounts/summary" should not be accessible
+        And the URL "/report/7/money-transfers/summary" should not be accessible
+        And the URL "/report/7/money-in/summary" should not be accessible
+        And the URL "/report/7/money-out/summary" should not be accessible
+        And the URL "/report/7/balance" should not be accessible
+        And the URL "/report/7/assets/summary" should not be accessible
+        And the URL "/report/7/debts/summary" should not be accessible
+        And the URL "/report/7/actions" should not be accessible
+        And the URL "/report/7/declaration" should not be accessible
 
     @deputy
     Scenario: deputy report download

--- a/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -107,11 +107,6 @@ Feature: Report submit
         And I click on "admin-documents"
         Then I should be on "/admin/documents/list"
         And I save the current URL as "admin-documents-list-new"
-        # test filters
-        When I click on "tab-archived"
-        Then I should see the "report-submission" region exactly 0 times
-        When I click on "tab-new"
-        Then I should see the "report-submission" region exactly 1 times
         # test search
         When I fill in the following:
             | search | behat001 |
@@ -137,10 +132,8 @@ Feature: Report submit
         When I go to the URL previously saved as "admin-documents-list-new"
         Then I check "Select behat001"
         When I click on "archive"
-        Then I should see the "report-submission" region exactly 0 times
-        When I click on "tab-archived"
-        Then I should see the "report-submission" region exactly 1 times
-        And each text should be present in the corresponding region:
+        And I click on "tab-archived"
+        Then each text should be present in the corresponding region:
             | Cly Hent | report-submission-1 |
             | behat001 | report-submission-1 |
             | Report + docs | report-submission-1 |

--- a/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -120,7 +120,8 @@ Feature: Admin unsubmit report (from client page)
     But I should not see the "report-unsubmitted" region
 
 
-  @deputy
+  # Magic: Expects reports to be submitted from previous tests
+  @deputy @magic
   Scenario: admin sees new submission and client page updated
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     # check report being resubmitted
@@ -128,7 +129,7 @@ Feature: Admin unsubmit report (from client page)
     Then I should see "SUBMITTED" in the "report-2016-label" region
     # check there is a new submission, with all the documents
     When I click on "admin-documents"
-    Then I should see the "report-submission" region exactly 3 times
+    Then I should see the "report-submission" region exactly 4 times
 
 
 

--- a/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -81,9 +81,7 @@ Feature: Admin unsubmit report (from client page)
     And I press "unsubmit_report_confirm_save"
     Then I should see "Unsubmitted" in the "report-2016-label" region
     And I should see "30 April 2022" in the "report-2016-due-date" region
-    When I click on "admin-documents"
-    Then I should see the "report-submission" region exactly 2 times
-    And I go to the URL previously saved as "admin-client-search-client-behat001"
+    When I go to the URL previously saved as "admin-client-search-client-behat001"
     And I click on "checklist" in the "report-2016" region
     And the response status code should be 200
 

--- a/tests/behat/features/deputy/04-user/00-login-logout.feature
+++ b/tests/behat/features/deputy/04-user/00-login-logout.feature
@@ -1,7 +1,7 @@
 Feature: deputy / login and logout functionalities
     @infra
     Scenario: manual login
-      Given I am logged in as "laydeputy103@publicguardian.gov.uk" with password "Abcd1234"
+      Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
       Then the URL should match "report/create/\d+"
 
     @deputy

--- a/tests/behat/features/deputy/05-acl/02-pages-security.feature
+++ b/tests/behat/features/deputy/05-acl/02-pages-security.feature
@@ -34,44 +34,43 @@ Feature: deputy / acl / security on pages
     And I press "report_save"
     And the form should be valid
 
-  @deputy
+  # Magic: uses report ID numbers
+  @deputy @magic
   Scenario: Malicious User cannot access other's pages
     # behat-user can access report n.2
     Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
     And I save the application status into "deputy-acl-before"
     Then the following "client" pages should return the following status:
-      | /report/5/overview         | 200 |
+      | /report/7/overview         | 200 |
       # decisions
-      | /report/5/decisions        | 200 |
+      | /report/7/decisions        | 200 |
       # contacts
-      | /report/5/contacts         | 200 |
-      | /report/5/contacts/add     | 200 |
+      | /report/7/contacts         | 200 |
+      | /report/7/contacts/add     | 200 |
       # assets
-      | /report/5/assets           | 200 |
-      | /report/5/assets/step-type | 200 |
+      | /report/7/assets           | 200 |
+      | /report/7/assets/step-type | 200 |
       # accounts
-      | /report/5/bank-accounts    | 200 |
+      | /report/7/bank-accounts    | 200 |
     # behat-malicious CANNOT access the same URLs
     Given I am logged in as "behat-malicious@publicguardian.gov.uk" with password "Abcd1234"
     # reload the status (as some URLs calls might have deleted data)
     And I load the application status from "deputy-acl-before"
     Then the following "client" pages should return the following status:
-      | /report/6/overview                | 200 |
-      | /report/5/overview                | 500 |
+      | /report/8/overview                | 200 |
+      | /report/7/overview                | 500 |
       # decisions
-      | /report/6/decisions               | 200 |
-      | /report/5/decisions               | 500 |
+      | /report/8/decisions               | 200 |
+      | /report/7/decisions               | 500 |
       # contacts
-      | /report/6/contacts                | 200 |
-      | /report/5/contacts                | 500 |
+      | /report/8/contacts                | 200 |
+      | /report/7/contacts                | 500 |
       # assets
-      | /report/6/assets                  | 200 |
-      | /report/5/assets                  | 500 |
+      | /report/8/assets                  | 200 |
+      | /report/7/assets                  | 500 |
       # accounts
-      | /report/5/bank-accounts           | 500 |
+      | /report/7/bank-accounts           | 500 |
       # submit
-      | /report/5/declaration             | 500 |
-      | /report/5/submitted               | 500 |
+      | /report/7/declaration             | 500 |
+      | /report/7/submitted               | 500 |
     And I load the application status from "deputy-acl-before"
-
-    

--- a/tests/behat/features/deputy/06-static-pages/04-privacy.feature
+++ b/tests/behat/features/deputy/06-static-pages/04-privacy.feature
@@ -8,7 +8,7 @@ Feature: Privacy
 
     @deputy
     Scenario: The footer provides a link to the privacy page when logged in
-        Given I am logged in as "laydeputy102@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-lay-deputy-102@publicguardian.gov.uk" with password "Abcd1234"
         Then the "Privacy notice" link, in the footer, url should contain "/privacy"
         And I go to "/privacy"
         And the response status code should be 200

--- a/tests/behat/features/deputy/07-infra-checks/00-documents.feature
+++ b/tests/behat/features/deputy/07-infra-checks/00-documents.feature
@@ -117,7 +117,7 @@ Feature: Infrastructure document tests
   Scenario: Can download submitted documents
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     When I click on "admin-documents"
-    And I check "Select test1030"
+    And I check "Select 103"
     And I click on "download"
     Then the page content should be a zip file containing files with the following files:
-        | Report_test1030_2016_2016-* | regexpName+sizeAtLeast | 30000 |
+        | Report_103_2016_2016-* | regexpName+sizeAtLeast | 30000 |

--- a/tests/behat/features/deputy/07-infra-checks/00-documents.feature
+++ b/tests/behat/features/deputy/07-infra-checks/00-documents.feature
@@ -2,7 +2,7 @@ Feature: Infrastructure document tests
 
   @infra
   Scenario: Can upload documents
-    Given I am logged in as "laydeputy103@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
     When I set the report start date to "1/1/2016"
     And I set the report end date to "31/12/2016"
     And I click on "report-start, edit-documents, start"
@@ -20,7 +20,7 @@ Feature: Infrastructure document tests
 
   @infra
   Scenario: Can generate report PDF
-    Given I am logged in as "laydeputy103@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
     When I click on "report-start, edit-report-preview, download-pdf"
     Then the response status code should be 200
     And the response should have the "Content-Type" header containing "application/pdf"
@@ -29,7 +29,7 @@ Feature: Infrastructure document tests
 
   @infra
   Scenario: Complete and submit report
-    Given I am logged in as "laydeputy103@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-lay-deputy-103@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "report-start"
     # Decisions
     When I click on "edit-decisions, start"


### PR DESCRIPTION
Infrastructure tests provide a good "early warning system" to identify problems with the infrastructure. Running them first allows us to be confident that any changes to infrastructure have been successful without having to wait for the entire suite(s) to finish.

However, running them before all other tests means having to tweak later tests to account for the new data in the system. For example, tests which rely on a report having ID "5" now need to use ID "7" because of the two new reports inserted by infrastructure tests.

In some circumstances I've had to update magic number tests (which I've now tagged `@magic` for future fixing), but I've mostly tried to rewrite tests so they don't rely on previous tests/suites having been completed.