### PR TITLE
DDPB-2622: Alter email tests to no longer clear log

### DIFF
--- a/tests/behat/bootstrap/EmailTrait.php
+++ b/tests/behat/bootstrap/EmailTrait.php
@@ -140,7 +140,7 @@ trait EmailTrait
     {
         $this->getFirstLinkInEmailMatching($partialLink);
 
-        $mail = $this->getEmailMock();
+        $mail = $this->getLastEmail();
         $mailTo = key($mail['to']);
 
         if ($mailTo !== 'the specified email address' && $mailTo != $to) {
@@ -149,15 +149,28 @@ trait EmailTrait
     }
 
     /**
-     * @Then the :index email should have been sent to :to
+     * @Then the last email should have been sent to :to
      */
-    public function theWhichEmailShouldHaveBeenSentTo($index, $to)
+    public function theLastEmailShouldHaveBeenSentTo($to)
     {
-        $mail = $this->getEmailMock(true, $index);
+        $mail = $this->getLastEmail();
         $mailTo = key($mail['to']);
 
         if ($mailTo !== 'the specified email address' && $mailTo != $to) {
             throw new \RuntimeException("Addressee '" . $mailTo . "' does not match the expected '" . $to . "'");
+        }
+    }
+
+    /**
+     * @Then the last :area email should not have been sent to :to
+     */
+    public function theLastEmailShouldNotHaveBeenSentTo($area, $to)
+    {
+        $mail = $this->getLastEmail($area);
+        $mailTo = key($mail['to']);
+
+        if ($mailTo === $to) {
+            throw new \RuntimeException("Last email unexpectedly sent to $to");
         }
     }
 
@@ -166,7 +179,7 @@ trait EmailTrait
      */
     private function getLinksFromEmailHtmlBody()
     {
-        $mailContent = base64_decode($this->getEmailMock()['parts'][0]['body']);
+        $mailContent = base64_decode($this->getLastEmail()['parts'][0]['body']);
 
         preg_match_all('#https?://[^\s"<]+#', $mailContent, $matches);
 
@@ -178,7 +191,7 @@ trait EmailTrait
      */
     public function mailContainsText($text)
     {
-        $mailContent = base64_decode($this->getEmailMock()['parts'][0]['body']);
+        $mailContent = base64_decode($this->getLastEmail()['parts'][0]['body']);
 
         if (strpos($mailContent, $text) === false) {
             throw new \Exception("Text: $text not found in email. Body: \n $mailContent");

--- a/tests/behat/bootstrap/EmailTrait.php
+++ b/tests/behat/bootstrap/EmailTrait.php
@@ -174,27 +174,6 @@ trait EmailTrait
     }
 
     /**
-     * @Then the :index email should contain a PDF of at least :minsizekb kb
-     */
-    public function theEmailAttachmentShouldContain($index, $minsizekb)
-    {
-        $mail = $this->getEmailMock(true, $index);
-
-        // find body of the part with the given contentType
-        $part = array_filter($mail['parts'], function ($part) {
-            return $part['contentType'] === 'application/pdf';
-        });
-        if (empty($part)) {
-            throw new \RuntimeException("PDF not found in $index email");
-        }
-        $pdfBody = base64_decode(array_shift($part)['body']);
-        $pdfLen = strlen($pdfBody) / 1024;
-        if ($pdfLen < $minsizekb) {
-            throw new \RuntimeException("found PDF $pdfLen Kb, must be at least $minsizekb Kb");
-        }
-    }
-
-    /**
      * @return array[array links, string mailContent]
      */
     private function getLinksFromEmailHtmlBody()
@@ -215,18 +194,6 @@ trait EmailTrait
 
         if (strpos($mailContent, $text) === false) {
             throw new \Exception("Text: $text not found in email. Body: \n $mailContent");
-        }
-    }
-
-    /**
-     * @Then the last email should not contain :text
-     */
-    public function mailNoContainsText($text)
-    {
-        $mailContent = base64_decode($this->getEmailMock()['parts'][0]['body']);
-
-        if (strpos($mailContent, $text) !== false) {
-            throw new \Exception("Text: $text unexpected in email. Body: \n $mailContent");
         }
     }
 }

--- a/tests/behat/bootstrap/EmailTrait.php
+++ b/tests/behat/bootstrap/EmailTrait.php
@@ -69,17 +69,6 @@ trait EmailTrait
     }
 
     /**
-     * @Given I reset the email log
-     */
-    public function iResetTheEmailLog()
-    {
-        $this->visitBehatLink('email-reset');
-        $this->visitBehatAdminLink('email-reset');
-
-        $this->assertNoEmailShouldHaveBeenSent();
-    }
-
-    /**
      * @param string $regexpr
      *
      * @throws \Exception

--- a/tests/behat/features/admin/01-admin.feature
+++ b/tests/behat/features/admin/01-admin.feature
@@ -6,7 +6,6 @@ Feature: admin / admin
 
   Scenario: login and add admin user
     Given emails are sent from "admin" area
-    And I reset the email log
     And I am on admin page "/"
     Then I should be on "/login"
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"

--- a/tests/behat/features/admin/02-cross-checks.feature
+++ b/tests/behat/features/admin/02-cross-checks.feature
@@ -18,7 +18,6 @@ Feature: admin / acl
     Scenario: An admin cannot reset password from the deputy area
         # check admin can recover password from admin site
         Given emails are sent from "admin" area
-        And I reset the email log
         And I am on admin login page
         When I click on "forgotten-password"
         Then I should be on "/password-managing/forgotten"
@@ -26,9 +25,8 @@ Feature: admin / acl
         And I press "password_forgotten_submit"
         Then the last email should have been sent to "behat-admin-user@publicguardian.gov.uk"
         # check admin CANNOT recover password from DEPUTY site
-        Given I reset the email log
-        And I go to "/login"
-        When I click on "forgotten-password"
+        When I go to "/login"
+        And I click on "forgotten-password"
         Then I should be on "/password-managing/forgotten"
         When I fill in "password_forgotten_email" with "behat-admin-user@publicguardian.gov.uk"
         And I press "password_forgotten_submit"

--- a/tests/behat/features/admin/02-cross-checks.feature
+++ b/tests/behat/features/admin/02-cross-checks.feature
@@ -32,4 +32,4 @@ Feature: admin / acl
         Then I should be on "/password-managing/forgotten"
         When I fill in "password_forgotten_email" with "behat-admin-user@publicguardian.gov.uk"
         And I press "password_forgotten_submit"
-        And no email should have been sent
+        And no "deputy" email should have been sent to "behat-admin-user@publicguardian.gov.uk"

--- a/tests/behat/features/admin/03-ad.feature
+++ b/tests/behat/features/admin/03-ad.feature
@@ -4,7 +4,6 @@ Feature: admin / AD
   Scenario: Create AD user
     Given I load the application status from "admin-init"
     And emails are sent from "admin" area
-    And I reset the email log
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I create a new "NDR-disabled" "AD" user "Assis" "Ter" with email "behat-ad@publicguardian.gov.uk" and postcode "HA3"
     Then I should see "behat-ad@publicguardian.gov.uk" in the "users" region

--- a/tests/behat/features/admin/04-case-manager.feature
+++ b/tests/behat/features/admin/04-case-manager.feature
@@ -3,7 +3,6 @@ Feature: admin / case manager
   Scenario: Create CM user
     Given I load the application status from "admin-init"
     And emails are sent from "admin" area
-    And I reset the email log
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I create a new "NDR-disabled" "case manager" user "Casero" "Managera" with email "behat-cm@publicguardian.gov.uk" and postcode "HA3"
     Then I should see "behat-cm@publicguardian.gov.uk" in the "users" region

--- a/tests/behat/features/deputy/01-registration-steps/01-create-users.feature
+++ b/tests/behat/features/deputy/01-registration-steps/01-create-users.feature
@@ -27,8 +27,7 @@ Feature: deputy / user / add user
 
   @deputy
   Scenario: add deputy user from registration page
-    And emails are sent from "deputy" area
-    And I reset the email log
+    Given emails are sent from "deputy" area
     When I am on "/register"
     And I add the following users to CASREC:
       | Case     | Surname | Deputy No | Dep Surname | Dep Postcode | Typeofrep |
@@ -49,7 +48,6 @@ Feature: deputy / user / add user
   @ndr
   Scenario: add deputy user (ndr)
     Given emails are sent from "admin" area
-    And I reset the email log
     And I load the application status from "init"
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
       # assert form OK

--- a/tests/behat/features/deputy/02-ndr/10-submit.feature
+++ b/tests/behat/features/deputy/02-ndr/10-submit.feature
@@ -20,7 +20,6 @@ Feature: ndr / report submit
     @ndr
     Scenario: NDR declaration and submission
         Given emails are sent from "deputy" area
-        And I reset the email log
         And I am logged in as "behat-user-ndr@publicguardian.gov.uk" with password "Abcd1234"
         And I click on "ndr-start, ndr-submit, ndr-declaration-page"
         Then the URL should match "/ndr/\d+/declaration"

--- a/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -15,7 +15,6 @@ Feature: Report submit
     @deputy
     Scenario: report submission
         Given emails are sent from "deputy" area
-        And I reset the email log
         And I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
         And I save the application status into "report-submit-pre"
         And I click on "report-start"
@@ -80,7 +79,6 @@ Feature: Report submit
     @deputy
     Scenario: deputy gives feedback after submitting report
         Given emails are sent from "deputy" area
-        And I reset the email log
         And I load the application status from "report-submit-pre"
         And I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
         And I click on "report-start"

--- a/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/01-102/21-check-and-submit.feature
@@ -62,9 +62,6 @@ Feature: Report submit
         And the response status code should be 200
         And the last email should contain "Thank you for submitting"
         And the last email should contain "next annual deputy report (for 01/01/2017 to 31/12/2017)"
-        #And the last email should have been sent to "behat-user@publicguardian.gov.uk"
-#        And the second_last email should have been sent to "behat-digideps@digital.justice.gov.uk"
-#        And the second_last email should contain a PDF of at least 40 kb
         And I save the application status into "report-submit-reports"
         And the report URL "overview" for "102 report" should not be accessible
         And the report URL "decisions/summary" for "102 report" should not be accessible

--- a/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -86,7 +86,7 @@ Feature: Admin unsubmit report (from client page)
 
   @deputy
   Scenario: Deputy resubmit report
-    And I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
     Then I should see "30 April 2022" in the "report-unsubmitted" region
     And I should see the "report-active" region
     But I should not see the "submitted-reports" region

--- a/tests/behat/features/deputy/03-report/02-103/02-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/02-103/02-check-and-submit.feature
@@ -2,6 +2,6 @@ Feature: Report submit
 
     @deputy
     Scenario: report 103 check is complete and submittable
-        And I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
         And I click on "report-start"
         Then the lay report should be submittable

--- a/tests/behat/features/deputy/03-report/03-104/00-start.feature
+++ b/tests/behat/features/deputy/03-report/03-104/00-start.feature
@@ -7,7 +7,7 @@ Feature: Report 104 start
 
   @deputy
   Scenario: test tabs for 104
-    And I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "report-start"
     Then the lay report should not be submittable
     And I should see the "edit-decisions" link

--- a/tests/behat/features/deputy/03-report/03-104/01-health-welfare.feature
+++ b/tests/behat/features/deputy/03-report/03-104/01-health-welfare.feature
@@ -7,7 +7,7 @@ Feature: Report 104 health welfare
 
   @deputy
   Scenario: test HW section
-    And I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "report-start, edit-lifestyle, start"
     Then the URL should match "report/\d+/lifestyle/step/1"
     Given the step with the following values CANNOT be submitted:

--- a/tests/behat/features/deputy/03-report/03-104/02-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/03-104/02-check-and-submit.feature
@@ -3,7 +3,6 @@ Feature: Report submit
     @deputy
     Scenario: submit 104
         Given emails are sent from "deputy" area
-        And I reset the email log
         And I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
         And I click on "report-start, report-submit, declaration-page"
         And I fill in the following:

--- a/tests/behat/features/deputy/04-user/01-reset-password.feature
+++ b/tests/behat/features/deputy/04-user/01-reset-password.feature
@@ -22,9 +22,9 @@ Feature: deputy / password reset
       And I press "password_forgotten_submit"
       Then the form should be valid
       And I click on "return-to-login"
-      And no email should have been sent
+      And no "deputy" email should have been sent to "ehat-not-existing@publicguardian.gov.uk"
       # existing email (email is now sent)
-      When I go to "/login" 
+      When I go to "/login"
       And I click on "forgotten-password"
       And I fill in "password_forgotten_email" with "behat-user@publicguardian.gov.uk"
       And I press "password_forgotten_submit"

--- a/tests/behat/features/deputy/04-user/01-reset-password.feature
+++ b/tests/behat/features/deputy/04-user/01-reset-password.feature
@@ -5,7 +5,6 @@ Feature: deputy / password reset
       Given I load the application status from "report-submit-pre"
       And I save the application status into "reset-password-start"
       And emails are sent from "deputy" area
-      And I reset the email log
       And I go to "/logout"
       And I go to "/login"
       When I click on "forgotten-password"

--- a/tests/behat/features/deputy/04-user/01-reset-password.feature
+++ b/tests/behat/features/deputy/04-user/01-reset-password.feature
@@ -1,8 +1,8 @@
 Feature: deputy / password reset
-    
+
     @deputy
     Scenario: Password reset
-      Given I load the application status from "report-submit-pre" 
+      Given I load the application status from "report-submit-pre"
       And I save the application status into "reset-password-start"
       And emails are sent from "deputy" area
       And I reset the email log
@@ -34,20 +34,20 @@ Feature: deputy / password reset
       # open password reset page
       When I open the "/user/password-reset/" link from the email
       # empty
-      When I fill in the following: 
+      When I fill in the following:
           | reset_password_password_first   |  |
           | reset_password_password_second  |  |
       And I press "reset_password_save"
       Then the form should be invalid
       #password mismatch
-      When I fill in the following: 
+      When I fill in the following:
           | reset_password_password_first   | Abcd1234 |
           | reset_password_password_second  | Abcd12345 |
       And I press "reset_password_save"
       Then the form should be invalid
       # (nolowercase, nouppercase, no number skipped as already tested in "set password" scenario)
       # correct !!
-      When I fill in the following: 
+      When I fill in the following:
           | reset_password_password_first   | Abcd12345 |
           | reset_password_password_second  | Abcd12345 |
       And I press "reset_password_save"
@@ -61,4 +61,3 @@ Feature: deputy / password reset
       Then the response status code should be 500
       # restore previous password
       And I load the application status from "reset-password-start"
-       

--- a/tests/behat/features/deputy/04-user/02-token-expired.feature
+++ b/tests/behat/features/deputy/04-user/02-token-expired.feature
@@ -1,11 +1,10 @@
 Feature: deputy / Activation link resending
     When the token expires, the user can have the activation link resent and continue from the user activation step
-    
+
     @deputy
     Scenario: Activation link: resend expired link and restart from activation step
         Given emails are sent from "deputy" area
-        And I reset the email log
-        And I load the application status from "report-submit-pre" 
+        And I load the application status from "report-submit-pre"
         And I change the user "behat-user@publicguardian.gov.uk" token to "behatuser123abc" dated last week
         When I go to "/user/activate/behatuser123abc"
         And I click on "ask-us-to-send-new-link"
@@ -19,7 +18,6 @@ Feature: deputy / Activation link resending
     @deputy
     Scenario: Forgotten password page: expired token shows error page and link to go back
         Given emails are sent from "deputy" area
-        And I reset the email log
         And I change the user "behat-user@publicguardian.gov.uk" token to "behatuser123abc" dated last week
         When I go to "/user/password-reset/behatuser123abc"
         And I click on "go-back-to-reset-password"

--- a/tests/behat/features/deputy/04-user/03-userselfregister.feature
+++ b/tests/behat/features/deputy/04-user/03-userselfregister.feature
@@ -5,7 +5,6 @@ Feature: User Self Registration
     Given I load the application status from "init"
     And I truncate the users from CASREC:
     And emails are sent from "deputy" area
-    And I reset the email log
       #
       # Form all empty
       #
@@ -156,7 +155,6 @@ Feature: User Self Registration
   Scenario: A user can self register and activate
     Given I load the application status from "init"
     And emails are sent from "deputy" area
-    And I reset the email log
     And I add the following users to CASREC:
       | Case     | Surname      | Deputy No | Dep Surname | Dep Postcode | Typeofrep |
       | 11112222 | Cross-Tolley | D001      | Tolley      | SW1 3RF      | OPG102    |

--- a/tests/behat/features/deputy/04-user/04-user-edit.feature
+++ b/tests/behat/features/deputy/04-user/04-user-edit.feature
@@ -52,7 +52,6 @@ Feature: deputy / report / edit user
     # @deputy
     # Scenario: Notification email sent for lay deputy changes
     #     Given emails are sent from "deputy" area
-    #     And I reset the email log
     #     And I am logged in as "laydeputy@publicguardian.gov.uk" with password "Abcd1234"
     #     And I click on "user-account, profile-show, profile-edit"
     #     When I fill in the following:

--- a/tests/behat/features/deputy/04-user/05-client-edit.feature
+++ b/tests/behat/features/deputy/04-user/05-client-edit.feature
@@ -61,7 +61,6 @@ Feature: deputy / report / edit client
     # @deputy
     # Scenario: edit client details
     #     Given emails are sent from "deputy" area
-    #     And I reset the email log
     #     And I am logged in as "laydeputy@publicguardian.gov.uk" with password "Abcd1234"
     #     And I click on "user-account, client-show, client-edit"
     #     When I fill in the following:

--- a/tests/behat/features/deputy/04-user/06-codeputies.feature
+++ b/tests/behat/features/deputy/04-user/06-codeputies.feature
@@ -5,7 +5,6 @@ Feature: Codeputy Self Registration
     Given I load the application status from "init"
     And I truncate the users from CASREC:
     And emails are sent from "deputy" area
-    And I reset the email log
     Given I add the following users to CASREC:
       | Case     | Surname | Deputy No | Dep Surname | Dep Postcode | Typeofrep |
       | 00000000 | Jones   | D000      | Goodby      | AA1 2BB      | OPG102    |
@@ -17,7 +16,6 @@ Feature: Codeputy Self Registration
   @deputy
   Scenario: absence of co-deputies section for a client without multiple assigned deputies
     Given emails are sent from "deputy" area
-    And I reset the email log
     When I am on "/register"
     And I fill in the following:
       | self_registration_firstname       | Jack                                              |
@@ -55,8 +53,7 @@ Feature: Codeputy Self Registration
 
   @deputy
   Scenario: The first co-deputy of a client is able to self register
-    And emails are sent from "deputy" area
-    And I reset the email log
+    Given emails are sent from "deputy" area
 
     # CORRECT
     When I am on "/register"
@@ -140,7 +137,6 @@ Feature: Codeputy Self Registration
   @deputy
   Scenario: The first co-deputy logs in and sees the deputy area and invites a codeputy
     Given emails are sent from "deputy" area
-    And I reset the email log
     When I am logged in as "behat-jack.goodby+mld1@digital.justice.gov.uk" with password "Abcd1234"
     Then the URL should match "/lay"
     And I should see the "codeputies" region

--- a/tests/behat/features/deputy/05-acl/01-cross-checks.feature
+++ b/tests/behat/features/deputy/05-acl/01-cross-checks.feature
@@ -21,7 +21,6 @@ Feature: deputy / acl / cross domain (admin and deputy) checks
     Scenario: A deputy cannot reset password from the admin area
         # check deputy can recover password from deputy site
         Given emails are sent from "deputy" area
-        And I reset the email log
         And I go to "/login"
         When I click on "forgotten-password"
         And I fill in "password_forgotten_email" with "behat-user@publicguardian.gov.uk"

--- a/tests/behat/features/deputy/05-acl/01-cross-checks.feature
+++ b/tests/behat/features/deputy/05-acl/01-cross-checks.feature
@@ -27,11 +27,3 @@ Feature: deputy / acl / cross domain (admin and deputy) checks
         And I fill in "password_forgotten_email" with "behat-user@publicguardian.gov.uk"
         And I press "password_forgotten_submit"
         Then the last email should have been sent to "behat-user@publicguardian.gov.uk"
-        # heck deputy CANNOT recover password from admin site
-        Given I reset the email log
-        And I am on admin login page
-        When I click on "forgotten-password"
-        And I fill in "password_forgotten_email" with "behat-user@publicguardian.gov.uk"
-        And I press "password_forgotten_submit"
-        #Then the response status code should be 200
-        And no "admin" email should have been sent to "behat-user@publicguardian.gov.uk"

--- a/tests/behat/features/deputy/05-acl/01-cross-checks.feature
+++ b/tests/behat/features/deputy/05-acl/01-cross-checks.feature
@@ -34,6 +34,4 @@ Feature: deputy / acl / cross domain (admin and deputy) checks
         And I fill in "password_forgotten_email" with "behat-user@publicguardian.gov.uk"
         And I press "password_forgotten_submit"
         #Then the response status code should be 200
-        And no email should have been sent
-
-    
+        And no "admin" email should have been sent to "behat-user@publicguardian.gov.uk"

--- a/tests/behat/features/deputy/05-acl/02-pages-security.feature
+++ b/tests/behat/features/deputy/05-acl/02-pages-security.feature
@@ -4,7 +4,6 @@ Feature: deputy / acl / security on pages
   Scenario: create another user with client and report with data
     # restore status of first report before submitting
     Given emails are sent from "admin" area
-    And I reset the email log
     Given I load the application status from "report-submit-pre"
     And I add the following users to CASREC:
       | Case     | Surname | Deputy No | Dep Surname | Dep Postcode | Typeofrep |

--- a/tests/behat/features/deputy/06-static-pages/02-cookie-policy.feature
+++ b/tests/behat/features/deputy/06-static-pages/02-cookie-policy.feature
@@ -10,24 +10,23 @@ Feature: Cookie Policy
         Then the "Cookies" link, in the footer, url should contain "https://www.gov.uk/help/cookies"
         And I am logged in as "admin@publicguardian.gov.uk" with password "Abcd1234"
         Then the "Cookies" link, in the footer, url should contain "https://www.gov.uk/help/cookies"
-            
+
     @deputy
     Scenario: When I click on the cookie link it appear in the same window
         Given I go to "/login"
         And I press "Cookies" in the footer
         Then I should be on "https://www.gov.uk/help/cookies"
-    
+
     @deputy
     Scenario: When I visit the site for the first time I see a cookie banner
-        And I go to "/login"
+        Given I go to "/login"
         Then I should see the cookie warning banner
         And the "Find out more about cookies" link url should contain "https://www.gov.uk/help/cookies"
-        
+
     @deputy
     Scenario: When I have visited the site previous, I don't see the cookie banner
-        And I go to "/login"
-        And I go to "/login"
+        Given I go to "/login"
         Then I should not see the cookie warning banner
-        
 
-    
+
+

--- a/tests/behat/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/tests/behat/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -3,7 +3,6 @@ Feature: Add PA users and activate PA user (journey)
   Scenario: add PA users
     Given I load the application status from "init-pa"
     And emails are sent from "admin" area
-    And I reset the email log
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
       # upload PA users
     When I click on "admin-upload-pa"
@@ -64,7 +63,6 @@ Feature: Add PA users and activate PA user (journey)
 
   Scenario: Register PA2 user
     Given emails are sent from "admin" area
-    And I reset the email log
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "send-activation-email" in the "user-behat-pa2publicguardiangovuk" region
     And I go to "/logout"
@@ -91,7 +89,6 @@ Feature: Add PA users and activate PA user (journey)
 
   Scenario: Register PA3 user
     Given emails are sent from "admin" area
-    And I reset the email log
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "send-activation-email" in the "user-behat-pa3publicguardiangovuk" region
     And I go to "/logout"

--- a/tests/behat/features/pa/03-report/04-submit-report.feature
+++ b/tests/behat/features/pa/03-report/04-submit-report.feature
@@ -14,7 +14,6 @@ Feature: Report submit (client 01000014)
 
     Scenario: 102 report submission
         Given emails are sent from "deputy" area
-        And I reset the email log
         # log in as team member to submit the report and test that named deputy details are displayed
         And I am logged in as "behat-pa1-team-member@publicguardian.gov.uk" with password "Abcd1234"
         And I click on "pa-report-open" in the "client-01000014" region

--- a/tests/behat/features/pa/03-report/05-report-resubmission.feature
+++ b/tests/behat/features/pa/03-report/05-report-resubmission.feature
@@ -42,7 +42,7 @@ Feature: Admin unsubmit and client re-submit
 
   @deputy
   Scenario: Admin checks report was re-submitted
-    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I go to the URL previously saved as "admin-client-01000014.url"
     Then I should see "SUBMITTED" in the "report-2016-to-2017" region
     # restore previous status

--- a/tests/behat/features/pa/04-dashboard-client-profile/13-settings.feature
+++ b/tests/behat/features/pa/04-dashboard-client-profile/13-settings.feature
@@ -4,7 +4,6 @@ Feature: PA settings
     Given I load the application status from "team-users-complete"
     And I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
     When I click on "org-settings"
-
     # settings page
     Then I should see the "user-accounts" link
     And I should see the "profile-show" link
@@ -59,7 +58,6 @@ Feature: PA settings
 
   Scenario: Notification email not sent for PA deputy changes
     Given emails are sent from "deputy" area
-    And I reset the email log
     And I am logged in as "behat-pa-admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "org-settings, profile-show, profile-edit"
     When I press "profile_save"

--- a/tests/behat/features/pa/04-dashboard-client-profile/13-settings.feature
+++ b/tests/behat/features/pa/04-dashboard-client-profile/13-settings.feature
@@ -64,7 +64,7 @@ Feature: PA settings
     And I click on "org-settings, profile-show, profile-edit"
     When I press "profile_save"
     Then I should be on "/org/settings/your-details"
-    And no email should have been sent
+    And the last "deputy" email should not have been sent to "behat-digideps+update-contact@digital.justice.gov.uk"
 
   Scenario: PA Admin logs in and updates profile and removes admin
     Given I am logged in as "behat-pa1-admin@publicguardian.gov.uk" with password "Abcd1234"

--- a/tests/behat/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/tests/behat/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -3,7 +3,6 @@ Feature: Add PROF users and activate PROF user (journey)
   Scenario: add PROF users
     Given I load the application status from "init-prof"
     And emails are sent from "admin" area
-    And I reset the email log
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
       # upload PROF users
     When I click on "admin-upload-pa"
@@ -55,7 +54,6 @@ Feature: Add PROF users and activate PROF user (journey)
 
   Scenario: Register PROF2 user
     Given emails are sent from "admin" area
-    And I reset the email log
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "send-activation-email" in the "user-behat-prof2publicguardiangovuk" region
     And I go to "/logout"
@@ -82,7 +80,6 @@ Feature: Add PROF users and activate PROF user (journey)
 
   Scenario: Register PROF3 user
     Given emails are sent from "admin" area
-    And I reset the email log
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "send-activation-email" in the "user-behat-prof3publicguardiangovuk" region
     And I go to "/logout"

--- a/tests/behat/features/prof/03-report/07-submit-report.feature
+++ b/tests/behat/features/prof/03-report/07-submit-report.feature
@@ -35,7 +35,6 @@ Feature: Report submit (client 01000010)
 
     Scenario: 102-5 report submission
         Given emails are sent from "deputy" area
-        And I reset the email log
         And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
         And I click on "pa-report-open" in the "client-01000010" region
         And I click on "edit-report_submit"

--- a/tests/behat/features/prof/04-dashboard-client-profile/13-settings.feature
+++ b/tests/behat/features/prof/04-dashboard-client-profile/13-settings.feature
@@ -47,7 +47,7 @@ Feature: PROF settings
     And I click on "org-settings, profile-show, profile-edit"
     When I press "profile_save"
     Then I should be on "/org/settings/your-details"
-    And no email should have been sent
+    And the last "deputy" email should not have been sent to "behat-digideps+update-contact@digital.justice.gov.uk"
 
   Scenario: PROF Admin logs in and updates profile and sees removeAdmin field but does not
     Given I am logged in as "behat-prof1-admin@publicguardian.gov.uk" with password "Abcd1234"

--- a/tests/behat/features/prof/04-dashboard-client-profile/13-settings.feature
+++ b/tests/behat/features/prof/04-dashboard-client-profile/13-settings.feature
@@ -42,7 +42,6 @@ Feature: PROF settings
 
   Scenario: Notification email not sent for professional deputy changes
     Given emails are sent from "deputy" area
-    And I reset the email log
     And I am logged in as "behat-prof-admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "org-settings, profile-show, profile-edit"
     When I press "profile_save"


### PR DESCRIPTION
This stops us clearing the email log in tests, giving a better audit of what emails have been sent and continuing to make parallisation of tests easier (because the log won't be cleared part way through a test).

In many cases, this simply involved removing the "I reset the email log" test step. In a few places I had to update other test steps to allow the test to keep passing (for example, looking explicitly at the last email rather than assuming it's the only one).

The only real interesting change is in `05-acl/01-cross-checks.feature` where I removed a bunch of test steps. This is because those steps were incorrectly configured and misrepresented what the application does. They happen to have passed up to this point because of the misconfiguration, so I thought it more clear to remove them.