### PR TITLE
DDPB 2631 NDR creation on enabling

### DIFF
--- a/src/AppBundle/Resources/views/Ndr/Ndr/_ndr_row.html.twig
+++ b/src/AppBundle/Resources/views/Ndr/Ndr/_ndr_row.html.twig
@@ -4,7 +4,7 @@
 
 <h2 class="heading-large">New deputy report</h2>
 
-<div class="card push-double--bottom">
+<div class="behat-region-ndr-card card push-double--bottom">
     <span class="status status-corner {{ ndrStatus.status }}">{{ (ndrStatus.status) | trans({}, 'common') }}</span>
     <h3 class="heading-medium flush--top">{{ client.firstname }} {{ client.lastname }}</h3>
     <div class="card-body soft-half--top">

--- a/src/AppBundle/Resources/views/Ndr/Ndr/_report_row.html.twig
+++ b/src/AppBundle/Resources/views/Ndr/Ndr/_report_row.html.twig
@@ -10,7 +10,7 @@
 {% if ndr.submitted %}
     {# CLICKABLE REPORT #}
     {% set status = reportActive ? reportActive.getStatus().status : 'notCreated' %}
-    <div class="card">
+    <div class="behat-region-report-card card">
         <span class="status status-corner {{ status }}">{{ (status) | trans({}, 'common') }}</span>
         {% if reportActive %}
             <h3 class="heading-medium flush--ends">
@@ -42,7 +42,7 @@
     </div>
 {% else %}
     {# REPORT NOT ACTIVE #}
-    <div class="card disabled">
+    <div class="behat-region-report-card card disabled">
         <span class="status status-corner not-available">{{ 'notAvailable' | trans({}, 'common') }}</span>
         <h3 class="heading-medium flush--top">{{ client.firstname }} {{ client.lastname }}</h3>
         <div class="card-body soft-half--top">

--- a/tests/behat/bootstrap/UserTrait.php
+++ b/tests/behat/bootstrap/UserTrait.php
@@ -287,13 +287,16 @@ trait UserTrait
     }
 
     /**
-     * @Given I enable NDR for user :email
+     * @Given I :action NDR for user :email
      */
-    public function iEnableNdrForUser($email)
+    public function iEnableNdrForUser($action, $email)
     {
         $this->clickOnBehatLink('user-' . $email);
 
-        $this->checkOption('admin_ndrEnabled');
+        strtolower($action) === 'enable' ?
+            $this->checkOption('admin_ndrEnabled') :
+            $this->uncheckOption('admin_ndrEnabled');
+
         $this->clickOnBehatLink('save');
         $this->theFormShouldBeValid();
         $this->assertResponseStatus(200);

--- a/tests/behat/bootstrap/UserTrait.php
+++ b/tests/behat/bootstrap/UserTrait.php
@@ -254,4 +254,48 @@ trait UserTrait
 
         return $value;
     }
+
+    /**
+     * @Given there is an activated :depType user with NDR :ndrStatus and email :email and password :password
+     */
+    public function iCreateAndActivateUser($depType, $ndrStatus, $email, $password)
+    {
+        $ndrStatus = 'NDR-' . $ndrStatus;
+        $this->iCreateTheUserWithEmailAndPostcode($ndrStatus, $depType, 'Lay', 'Dep', $email, 'SW11AA');
+        $this->iActivateTheUserAndSetThePasswordTo($password);
+
+        $this->iAddTheFollowingUsersToCASREC(new TableNode([
+            ['Case', 'Surname', 'Deputy No', 'Dep Surname', 'Dep Postcode', 'Typeofrep'],
+            ['12355555', 'Jones', '00213', 'Dep', 'SW11AA', 'OPG102']
+        ]));
+
+        $this->iSetTheUserDetailsTo(new TableNode([
+            ['address', '16 Deputy Road', 'Beeston', 'Notts', 'PREFILLED', 'GB'],
+            ['phone', '07987123123', '', '', '', '']
+        ]));
+
+        $this->iSetTheClientDetailsTo(new TableNode([
+            ['name', 'Client', 'Jones', '', '', ''],
+            ['caseNumber', '12355555', '', '', '', ''],
+            ['address', '16 Client Road', 'Beeston', 'Notts', 'NG12LK', 'GB'],
+            ['courtDate', 1, 11, 2018, '', ''],
+            ['phone', '07987123122', '', '', '', '']
+        ]));
+
+        $this->iSetTheReportStartDateToAndEndDateTo('1/11/2018');
+        $this->iSetTheReportEndDateToAndEndDateTo('1/10/2019');
+    }
+
+    /**
+     * @Given I enable NDR for user :email
+     */
+    public function iEnableNdrForUser($email)
+    {
+        $this->clickOnBehatLink('user-' . $email);
+
+        $this->checkOption('admin_ndrEnabled');
+        $this->clickOnBehatLink('save');
+        $this->theFormShouldBeValid();
+        $this->assertResponseStatus(200);
+    }
 }

--- a/tests/behat/features/admin/05-ndr-enablement.feature
+++ b/tests/behat/features/admin/05-ndr-enablement.feature
@@ -1,0 +1,13 @@
+Feature: Enabling and disabling NDR for Lay deputies
+
+  Scenario: Enabling NDR for the first time when Client already has a Report retrieves a new NDR report when the Client logs in and disables the Report
+    Given emails are sent from "admin" area
+    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    And there is an activated "Lay Deputy" user with NDR "disabled" and email "red-squirrel@publicguardian.gov.uk" and password "Abcd1234"
+    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    When I enable NDR for user "red-squirrelpublicguardiangovuk"
+    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "Abcd1234"
+    Then I should see the "ndr-start" link
+
+  Scenario: Disabling NDR when Client already has a Report removes NDR from Client dashboard and enables completion of Report
+  Scenario: Re-enabling NDR for a Client retrieves the existing NDR when the Client logs in and disables the Report

--- a/tests/behat/features/admin/05-ndr-enablement.feature
+++ b/tests/behat/features/admin/05-ndr-enablement.feature
@@ -1,13 +1,31 @@
 Feature: Enabling and disabling NDR for Lay deputies
 
-  Scenario: Enabling NDR for the first time when Client already has a Report retrieves a new NDR report when the Client logs in and disables the Report
+  Scenario: Enabling and disabling NDR from admin toggles the availability of the NDR and Report accordingly
     Given emails are sent from "admin" area
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And there is an activated "Lay Deputy" user with NDR "disabled" and email "red-squirrel@publicguardian.gov.uk" and password "Abcd1234"
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
-    When I enable NDR for user "red-squirrelpublicguardiangovuk"
-    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "Abcd1234"
-    Then I should see the "ndr-start" link
 
-  Scenario: Disabling NDR when Client already has a Report removes NDR from Client dashboard and enables completion of Report
-  Scenario: Re-enabling NDR for a Client retrieves the existing NDR when the Client logs in and disables the Report
+    # Enabling NDR makes NDR available and disables the Report
+    When I "enable" NDR for user "red-squirrelpublicguardiangovuk"
+    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "Abcd1234"
+    Then I should see "Start now" in the "ndr-card" region
+    And I should see "Not available" in the "report-card" region
+    # (Store the NDR URL to retrieve for upcoming test)
+    When I click on "ndr-start"
+    Then I save the report as "red-squirrel-ndr"
+
+    # Disabling NDR makes NDR unavailable and enables the Report
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    And I "disable" NDR for user "red-squirrelpublicguardiangovuk"
+    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "Abcd1234"
+    Then I should see "Start now" in the "report-active" region
+
+    # Re-enabling NDR retrieves the previous NDR (instead of creating a new one)
+    When I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    And I "enable" NDR for user "red-squirrelpublicguardiangovuk"
+    And I am logged in as "red-squirrel@publicguardian.gov.uk" with password "Abcd1234"
+    Then I should see "Start now" in the "ndr-card" region
+    And I should see "Not available" in the "report-card" region
+    When I go to the report URL "overview" for "red-squirrel-ndr"
+    Then the response status code should be 200


### PR DESCRIPTION
Adds Behat tests to verify that when NDR is enabled for a Deputy, that the Deputy can log in and has access to a new NDR. When disabled, access to the NDR is removed. And if re-enabled, access to the _previous_ NDR is recovered.

Added a catch all behat method to create, register, and activate a user.