### PR TITLE
Remove deprecated 'reset the email log' command

### DIFF
--- a/tests/behat/features/deputy/04-user/06-codeputies.feature
+++ b/tests/behat/features/deputy/04-user/06-codeputies.feature
@@ -158,7 +158,6 @@ Feature: Codeputy Self Registration
   @deputy @ndr
   Scenario: NDR user can see a list of deputies in the codeputy region
     Given emails are sent from "deputy" area
-    And I reset the email log
     # Set up to a register an NDR client with multiple deputies
     And I add the following users to CASREC:
       | Case     | Surname | Deputy No | Dep Surname | Dep Postcode | Typeofrep | NDR  |


### PR DESCRIPTION
## Purpose
There is a warning on [automated tests](https://jenkins.service.opg.digital/job/Digi-Deps/view/Master/job/Test_Master/128/consoleFull) about a call to the deprecated "I reset the email log" test step. This doesn't cause the test suite to fail.

## Approach
I removed the line since it doesn't now do anything.

## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [N/A] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [N/A] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [N/A] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [N/A] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [N/A] The product team have tested these changes
