### PR TITLE
DDPB-2602: Adds NA option to deputy costs section of checklist

### DIFF
--- a/src/AppBundle/Form/Admin/ReportChecklistType.php
+++ b/src/AppBundle/Form/Admin/ReportChecklistType.php
@@ -123,7 +123,7 @@ class ReportChecklistType extends AbstractType
             ]);
 
             $builder->add('hasDeputyOverchargedFromPreviousEstimates', FormTypes\ChoiceType::class, [
-                'choices' => ['Yes' => 'yes', 'No' => 'no'],
+                'choices' => ['Yes' => 'yes', 'No' => 'no', 'Not applicable' => 'na'],
                 'expanded' => true
             ]);
         }

--- a/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/checklist_formatted_body.html.twig
@@ -332,6 +332,8 @@
                         <td class="label">{{ 'yes' | trans({}, 'common' ) }}</td>
                         <td class="checkbox value">{% if checklist.hasDeputyOverchargedFromPreviousEstimates == 'no' %}X{% else %}&nbsp;{% endif %}</td>
                         <td class="label">{{ 'no' | trans({}, 'common' ) }}</td>
+                        <td class="checkbox value">{% if checklist.hasDeputyOverchargedFromPreviousEstimates == 'na' %}X{% else %}&nbsp;{% endif %}</td>
+                        <td class="label">{{ 'notApplicable' | trans({}, 'common' ) }}</td>
                     </tr>
                 </tbody>
             </table>            

--- a/tests/behat/features/prof/03-report/08-lodging-checklist.feature
+++ b/tests/behat/features/prof/03-report/08-lodging-checklist.feature
@@ -75,6 +75,7 @@ Feature: Admin report checklist
       | report_checklist_profCostsReasonableAndProportionate_1 |
       | report_checklist_hasDeputyOverchargedFromPreviousEstimates_0 |
       | report_checklist_hasDeputyOverchargedFromPreviousEstimates_1 |
+      | report_checklist_hasDeputyOverchargedFromPreviousEstimates_2 |
       | report_checklist_nextBillingEstimatesSatisfactory_0    |
       | report_checklist_nextBillingEstimatesSatisfactory_1    |
       | report_checklist_caseWorkerSatisified_0                |
@@ -141,7 +142,7 @@ Feature: Admin report checklist
     And I fill in "report_checklist_bondOrderMatchCasrec_0" with "yes"
     And I fill in "report_checklist_paymentsMatchCostCertificate_0" with "yes"
     And I fill in "report_checklist_profCostsReasonableAndProportionate_0" with "yes"
-    And I fill in "report_checklist_hasDeputyOverchargedFromPreviousEstimates_1" with "no"
+    And I fill in "report_checklist_hasDeputyOverchargedFromPreviousEstimates_2" with "na"
     And I fill in "report_checklist_nextBillingEstimatesSatisfactory_1" with "yes"
     And I fill in "report_checklist_futureSignificantDecisions_0" with "yes"
     And I fill in "report_checklist_hasDeputyRaisedConcerns_1" with "no"
@@ -168,7 +169,7 @@ Feature: Admin report checklist
       | report_checklist_paymentsMatchCostCertificate_0               | yes                 |
       | report_checklist_profCostsReasonableAndProportionate_0        | yes                 |
       | report_checklist_paymentsMatchCostCertificate_0               | yes                 |
-      | report_checklist_hasDeputyOverchargedFromPreviousEstimates_1  | no                  |
+      | report_checklist_hasDeputyOverchargedFromPreviousEstimates_2  | na                  |
       | report_checklist_nextBillingEstimatesSatisfactory_1           | yes                  |
       | report_checklist_futureSignificantDecisions_0          | yes                |
       | report_checklist_hasDeputyRaisedConcerns_1             | no                 |


### PR DESCRIPTION
## Purpose
Adds an N/A option for a question on the checklist.

Fixes [DDPB-2602](https://opgtransform.atlassian.net/browse/DDPB-2602)

## Approach
A straightforward copy and paste approach of other N/A options on the checklist

## Learning
None

## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [TBC] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [TBC] The product team have tested these changes
