### PR TITLE
DDPB-2621: Remove 'details-banner' wrapper div for non pa/prof deputies

### DIFF
--- a/src/AppBundle/Resources/views/Layouts/application.html.twig
+++ b/src/AppBundle/Resources/views/Layouts/application.html.twig
@@ -107,8 +107,6 @@
 
     {% block linkBack %}{% endblock %}
 
-    {% block progressBar %}{% endblock %}
-
     {% block validationSummary %}
         {% if form | default(false) %}
             {{ form_errors_list(form) }}
@@ -145,6 +143,8 @@
         {% block pageTitle %} Deputy report {% endblock %}
         {% block supportTitleBottom %}{% endblock %}
     </h1>
+
+    {% block progressBar %}{% endblock %}
 
     {% block pageContent %}{% endblock %}
 

--- a/src/AppBundle/Resources/views/Org/ClientProfile/_detailsBanner.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/_detailsBanner.html.twig
@@ -1,5 +1,5 @@
+{% if app.user and (app.user.isDeputyProf() or app.user.isDeputyPa()) and report is defined  and report is not null %}
 <div class="details-banner">
-    {% if app.user and (app.user.isDeputyProf() or app.user.isDeputyPa()) and report is defined  and report is not null %}
     <div class="details-content behat-region-client-details-banner">
         <p>
             <span class="bold">{{ 'clientName' | trans({}, 'client-profile') }} </span>{{ report.client.fullName | title }}
@@ -24,4 +24,6 @@
             {% endif %}
         </h3>
     </div>
+{% if app.user and (app.user.isDeputyProf() or app.user.isDeputyPa()) and report is defined  and report is not null %}
 </div>
+{% endif %}


### PR DESCRIPTION
## Purpose
The `details-banner` class is being used across the board, but it shouldn't be applied to lay deputy pages. Where it is, it's creating unnecessary whitespace and pushing the page content down:

![image](https://user-images.githubusercontent.com/100852/58704476-0992c680-83a4-11e9-9798-f18fff716c27.png)

Fixes [DDPB-2621](https://opgtransform.atlassian.net/browse/DDPB-2621)

## Approach
As suggested in ticket, I removed the `details-banner` container when the user isn't a PA or professional deputy.

I identified one area where this doesn't work, which is the registration pages where it overlaps with the progress bar:

<img width="1016" alt="Screenshot 2019-05-31 at 11 38 47" src="https://user-images.githubusercontent.com/100852/58704548-54acd980-83a4-11e9-8a0b-9c86cb3b4d6a.png">

The reason this is an issue is that the registration pages are the only ones without a title, which would usually balance the left-hand side. To fix it then, I rearranged those pages to put the title above the progress bar:

<img width="1016" alt="Screenshot 2019-05-31 at 11 39 00" src="https://user-images.githubusercontent.com/100852/58704645-a6edfa80-83a4-11e9-8eac-9abc1118e6fb.png">

I think this new layout is just as readable and more consistent. Since the progress bar is a custom element (i.e. not from GovUK framework) we don't need to worry about breaking any rules.

I checked the rest of the application forms and didn't find any other display issues.

## Learning
I spent some time looking at the GovUK frontend framework to check if the component was used, which is useful knowledge for DDPB-2646.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
  - Covered in #1232
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
  - Covered in #1232
- [x] The product team have tested these changes
