### PR TITLE
Ddpb 2655 cookie link tests fix

### DIFF
--- a/src/AppBundle/Resources/views/Layouts/application.html.twig
+++ b/src/AppBundle/Resources/views/Layouts/application.html.twig
@@ -19,7 +19,7 @@
 {% block cookieMessage %}
     <p>
         GOV.UK uses cookies to make the site simpler.
-        <a href="https://www.gov.uk/help/cookies">Find out more about cookies</a>
+        <a href="https://www.gov.uk/help/cookie-details">Find out more about cookies</a>
     </p>
 {% endblock %}
 

--- a/src/AppBundle/Resources/views/Layouts/application.html.twig
+++ b/src/AppBundle/Resources/views/Layouts/application.html.twig
@@ -161,7 +161,7 @@
         <a href="{{path('privacy')}}">Privacy notice</a>
     </li>
     <li>
-        <a href="https://www.gov.uk/help/cookies">Cookies</a>
+        <a href="https://www.gov.uk/help/cookie-details">Cookies</a>
     </li>
 {% endblock %}
 

--- a/tests/behat/features/deputy/06-static-pages/02-cookie-policy.feature
+++ b/tests/behat/features/deputy/06-static-pages/02-cookie-policy.feature
@@ -7,21 +7,21 @@ Feature: Cookie Policy
     @deputy
     Scenario: I see a link in the bottom footer of the service on every page
         Given I go to "/login"
-        Then the "Cookies" link, in the footer, url should contain "https://www.gov.uk/help/cookies"
+        Then the "Cookies" link, in the footer, url should contain "https://www.gov.uk/help/cookie-details"
         And I am logged in as "admin@publicguardian.gov.uk" with password "Abcd1234"
-        Then the "Cookies" link, in the footer, url should contain "https://www.gov.uk/help/cookies"
+        Then the "Cookies" link, in the footer, url should contain "https://www.gov.uk/help/cookie-details"
 
     @deputy
     Scenario: When I click on the cookie link it appear in the same window
         Given I go to "/login"
         And I press "Cookies" in the footer
-        Then I should be on "https://www.gov.uk/help/cookies"
+        Then I should be on "https://www.gov.uk/help/cookie-details"
 
     @deputy
     Scenario: When I visit the site for the first time I see a cookie banner
         Given I go to "/login"
         Then I should see the cookie warning banner
-        And the "Find out more about cookies" link url should contain "https://www.gov.uk/help/cookies"
+        And the "Find out more about cookies" link url should contain "https://www.gov.uk/help/cookie-details"
 
     @deputy
     Scenario: When I have visited the site previous, I don't see the cookie banner


### PR DESCRIPTION
## Purpose
Follwing .gov.uk change to the cookie page from /cookies to /cookie-details, this branch fixes our behat tests and main template which contains the cookie link.

## Approach
Ive updated the linkto be the correct page and updated the tests accordingly. Ive replaced the tests to reference the actual page whereas another approach might be to just test for a 200 response. However I have adopted an approach whereby we would want this test to fail in the event of any external changes to gov.uk so we can verify the page content is still applicable to the link we are generating on DD.

## Learning
If these tests fail in the future, we need to check that the gov.uk site still contains relevant content

## Checklist
- [x] I have performed a self-review of my own code
- [n/a] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [ ] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [ ] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [ ] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
