### PR TITLE
Strengthen check on FRONTEND_TEST_ENABLED environment variable

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -17,7 +17,7 @@ $loader->register(true);
 require_once __DIR__ . '/../app/AppKernel.php';
 //require_once __DIR__.'/../app/AppCache.php';
 
-$kernel = new AppKernel(getenv('FRONTEND_TEST_ENABLED') ? 'test' : 'prod', false);
+$kernel = new AppKernel(strtolower(getenv('FRONTEND_TEST_ENABLED')) === 'true' ? 'test' : 'prod', false);
 //$kernel->loadClassCache();
 //$kernel = new AppCache($kernel);
 $request = Request::createFromGlobals();


### PR DESCRIPTION
## Purpose
The check on FRONTEND_TEST_ENABLED is not strong enough: setting the variable to variable to "false" caused failures

## Approach
Strengthen check on FRONTEND_TEST_ENABLED environment variable

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [ ] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [ ] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [ ] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
