### PR TITLE
Expose the environment on the Frontend availability page

### DIFF
--- a/src/AppBundle/Controller/ManageController.php
+++ b/src/AppBundle/Controller/ManageController.php
@@ -24,6 +24,7 @@ class ManageController extends AbstractController
         $response = $this->render('AppBundle:Manage:availability.html.twig', [
             'services' => $services,
             'errors' => $errors,
+            'environment' => $this->get('kernel')->getEnvironment(),
         ]);
 
         $response->setStatusCode($healthy ? 200 : 500);

--- a/src/AppBundle/Resources/views/Manage/availability.html.twig
+++ b/src/AppBundle/Resources/views/Manage/availability.html.twig
@@ -1,5 +1,8 @@
 <h1>App Health Check</h1>
 <ul>
+  <li>
+    <b>Environment</b>: {{ environment }}
+  </li>
   {% for service in services %}
     <li>
       <b>{{ service.name }}</b>:
@@ -9,5 +12,5 @@
         <span style="color: #FF0000">{{ service.errors | nl2br }}</span>
       {% endif %}
     </li>
-  {% endfor %} 
+  {% endfor %}
 </ul>


### PR DESCRIPTION
## Purpose
We recently had an issue identifying what configuration environment we'd deployed to a server. This will make it easier to determine that in the future by displaying the environment clearly on the availability page.

Fixes [DDPB-2656](https://opgtransform.atlassian.net/browse/DDPB-2656)

## Approach
I passed `$kernel->getEnvironment()` to the template and rendered it in the list.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [N/A] The product team have tested these changes
