### PR TITLE
Ddpb 2568 add checklist jump link

### DIFF
--- a/src/AppBundle/Resources/translations/admin-checklist.en.yml
+++ b/src/AppBundle/Resources/translations/admin-checklist.en.yml
@@ -32,6 +32,7 @@ checklistPage:
     infoProvided: Information provided
     noInfoReceived: No information received
   backToClientDetails: Back to client details
+  backToQuestion: Back to question
   expected: Expected
   submitted: Submitted
   deputysFullName: Deputy's full name

--- a/src/AppBundle/Resources/views/Admin/Client/Report/partials/_money-in-and-out.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Client/Report/partials/_money-in-and-out.html.twig
@@ -289,6 +289,7 @@
         </details>
     {% endif %}
 
+    <a href="#moneyInOut" class="behat-link-back-to-money-in-out">{{ (page ~ '.backToQuestion') | trans }}</a>
 </div>
 
 

--- a/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -129,7 +129,7 @@ Feature: Admin report checklist
     Then the URL should match "/admin/report/\d+/checklist"
 
 
-  @deputy @shauns
+  @deputy
   Scenario: Admin completes checklist
     Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     # Navigate to checklist via search
@@ -149,8 +149,6 @@ Feature: Admin report checklist
     And I fill in "report_checklist_debtsManaged_0" with "yes"
     And I fill in "report_checklist_openClosingBalancesMatch_1" with "no"
     And I fill in "report_checklist_accountsBalance_2" with "na"
-    When I click on "back-to-money-in-out"
-    Then the URL should match "/admin/report/\d+/checklist#moneyInOut"
     And I fill in "report_checklist_moneyMovementsAcceptable_0" with "yes"
     And I fill in "report_checklist_bondAdequate_1" with "no"
     And I fill in "report_checklist_bondOrderMatchCasrec_2" with "na"
@@ -162,6 +160,8 @@ Feature: Admin report checklist
     Then I click on "save-progress"
     And the response status code should be 200
     And the URL should match "/admin/report/\d+/checklist"
+    When I click on "back-to-money-in-out"
+    Then the URL should match "/admin/report/\d+/checklist#moneyInOut"
     And each text should be present in the corresponding region:
       | Admin User, OPG Admin | last-saved-by |
     # Assert form reloads with fields saved

--- a/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -149,6 +149,8 @@ Feature: Admin report checklist
     And I fill in "report_checklist_debtsManaged_0" with "yes"
     And I fill in "report_checklist_openClosingBalancesMatch_1" with "no"
     And I fill in "report_checklist_accountsBalance_2" with "na"
+    When I click on "back-to-money-in-out"
+    Then the URL should match "/admin/report/\d+/checklist#moneyInOut"
     And I fill in "report_checklist_moneyMovementsAcceptable_0" with "yes"
     And I fill in "report_checklist_bondAdequate_1" with "no"
     And I fill in "report_checklist_bondOrderMatchCasrec_2" with "na"


### PR DESCRIPTION
## Purpose
To better allow case managers to complete the report checklist.

Fixes [DDPB-2568]

## Approach
Adds a link just beyond all of the money in-out panels to allow user to quickly to return to the question for which the panel information relates.

## Learning
Clicking this anchor link removes any previously entered data in behat only. Hence the test had to be moved to be after data was persisted. Browser behaves normally.

## Checklist
- [x] I have performed a self-review of my own code
- [n/a] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
Checked with team. Fixed in DDPB-2648
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
Checked with team. Fixed in DDPB-2648
- [ ] The product team have tested these changes
