### PR TITLE
DDPB-2581: Adds notice to Notes section

### DIFF
--- a/src/AppBundle/Controller/Org/NoteController.php
+++ b/src/AppBundle/Controller/Org/NoteController.php
@@ -32,6 +32,7 @@ class NoteController extends AbstractController
         $this->denyAccessUnlessGranted('add-note', $client, 'Access denied');
 
         $report = $client->getCurrentReport();
+        $report->setClient($client);
 
         $note = new EntityDir\Note($client);
 
@@ -90,7 +91,7 @@ class NoteController extends AbstractController
         }
 
         return [
-            'report'  => $note->getClient()->getCurrentReport(),
+            'report'  => $note->getClient()->getCurrentReport()->setClient($note->getClient()),
             'form'  => $form->createView(),
             'client' => $note->getClient(),
             'backLink' => $this->generateClientProfileLink($note->getClient())

--- a/src/AppBundle/Resources/translations/client-notes.en.yml
+++ b/src/AppBundle/Resources/translations/client-notes.en.yml
@@ -32,3 +32,4 @@ form:
     label: Description
   save:
     label: Save note
+pageNotice: Notes are for personal reference only, they are not viewable by the OPG

--- a/src/AppBundle/Resources/translations/client-profile.en.yml
+++ b/src/AppBundle/Resources/translations/client-profile.en.yml
@@ -20,6 +20,7 @@ clientReports:
   attachDocuments: Attach documents
 clientNotes:
   heading: Notes
+  notice: Notes are for personal reference only, they are not viewable by the OPG
   noNotes: No notes
   note: Note
   category: Category

--- a/src/AppBundle/Resources/views/Org/ClientProfile/_notes.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/_notes.html.twig
@@ -9,7 +9,7 @@
     </summary>
 
     <div class="panel-body soft-half">
-
+        <div>{{ (page ~ '.notice') | trans }}</div>
         <a href="{{ path('add_note', {'clientId': client.id}) }}" class="bold-small action-link right behat-link-add-notes-button">
             <span class="icon icon-plus"></span>
             {{ (page ~ '.addNote') | trans }}

--- a/src/AppBundle/Resources/views/Org/ClientProfile/addNote.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/addNote.html.twig
@@ -17,6 +17,9 @@
 {% endblock %}
 
 {% block pageContent %}
+
+    {{ macros.notification('info', ('pageNotice') | trans) }}
+
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
     {{ form_input(form.title,'form.title') }}

--- a/src/AppBundle/Resources/views/Org/ClientProfile/editNote.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/editNote.html.twig
@@ -17,6 +17,9 @@
 {% endblock %}
 
 {% block pageContent %}
+
+    {{ macros.notification('info', ('pageNotice') | trans) }}
+
     {{ form_start(form, {attr: {novalidate: 'novalidate' }}) }}
 
     {{ form_input(form.title,'form.title') }}


### PR DESCRIPTION
## Purpose
Adds an informative notice to Note related sections/pages.

Addresses [DDPB-2581](https://opgtransform.atlassian.net/browse/DDPB-2581)

## Approach
Simple re-use of existing macros.

## Learning
Discovered that the `client` variable required by Twig was not set, despite Twig referencing it. This is a silent error on production, and displays an empty string where referenced. On dev, Twig displays a fatal error and therefore the issue was highlighted (notably, Behat tests did not pick this up as they run in prod mode).

I have set the required `$client` var for the template.

## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [N/A] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
