### PR TITLE
DDPB-2657: Remove trivial tests which save/load application state

### DIFF
--- a/docker/confd/templates/behat.yml.tmpl
+++ b/docker/confd/templates/behat.yml.tmpl
@@ -40,18 +40,6 @@ default:
                 - DigidepsBehat\FeatureContext: [{ dbName: "api", sessionName: 'digideps' }]
             {{ end }}
 
-        admin:
-            description: End to end journey for Admin user
-            paths:    [ %paths.base%/features/admin ]
-            filters:
-                tags: "~@javascript"
-            contexts:
-            {{ if exists "/api/database/name" }}
-                - DigidepsBehat\FeatureContext: [{ dbName: {{ getv "/api/database/name" }} }]
-            {{ else }}
-                - DigidepsBehat\FeatureContext: [{ dbName: "api" }]
-            {{ end }}
-
         ndr:
             description: End to end journey for NDR-enabled Lay deputy user (fewer checks than deputy suite for common functionalities)
             paths:    [ %paths.base%/features/deputy ]

--- a/docker/confd/templates/behat.yml.tmpl
+++ b/docker/confd/templates/behat.yml.tmpl
@@ -84,12 +84,6 @@ default:
                 - DigidepsBehat\FeatureContext: [{ dbName: api, sessionName: 'digideps' }]
             {{ end }}
 
-        components:
-            description: Tests related to textareas
-            paths:    [ %paths.base%/features/components ]
-            mink_session: default
-            contexts: [ DigidepsBehat\FeatureContext ]
-
     extensions:
         Behat\Symfony2Extension: ~
         Behat\MinkExtension\ServiceContainer\MinkExtension:

--- a/tests/behat/features/admin/00-prechecks.feature
+++ b/tests/behat/features/admin/00-prechecks.feature
@@ -4,4 +4,3 @@ Feature: admin / pre checks
     Scenario: check app status
         Given the admin area works properly
         And the response status code should be 200
-        And I save the application status into "admin-init"

--- a/tests/behat/features/admin/01-admin.feature
+++ b/tests/behat/features/admin/01-admin.feature
@@ -87,7 +87,6 @@ Feature: admin / admin
 
   Scenario: change user password on admin area
     Given I am logged in to admin as "behat-admin-user@publicguardian.gov.uk" with password "Abcd1234"
-    And I save the application status into "admin-pasword-change-init"
     And I click on "user-account"
     Then the response status code should be 200
     And I click on "password-edit"
@@ -138,7 +137,6 @@ Feature: admin / admin
     And I press "change_password_save"
     Then the form should be valid
     And I should be on "/deputyship-details/your-details/change-password/done"
-    And I load the application status from "admin-pasword-change-init"
 
 
   Scenario: service notification

--- a/tests/behat/features/admin/03-ad.feature
+++ b/tests/behat/features/admin/03-ad.feature
@@ -2,8 +2,7 @@ Feature: admin / AD
 
   @ad
   Scenario: Create AD user
-    Given I load the application status from "admin-init"
-    And emails are sent from "admin" area
+    Given emails are sent from "admin" area
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I create a new "NDR-disabled" "AD" user "Assis" "Ter" with email "behat-ad@publicguardian.gov.uk" and postcode "HA3"
     Then I should see "behat-ad@publicguardian.gov.uk" in the "users" region

--- a/tests/behat/features/admin/04-case-manager.feature
+++ b/tests/behat/features/admin/04-case-manager.feature
@@ -1,8 +1,7 @@
 Feature: admin / case manager
 
   Scenario: Create CM user
-    Given I load the application status from "admin-init"
-    And emails are sent from "admin" area
+    Given emails are sent from "admin" area
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I create a new "NDR-disabled" "case manager" user "Casero" "Managera" with email "behat-cm@publicguardian.gov.uk" and postcode "HA3"
     Then I should see "behat-cm@publicguardian.gov.uk" in the "users" region

--- a/tests/behat/features/deputy/01-registration-steps/00-prechecks.feature
+++ b/tests/behat/features/deputy/01-registration-steps/00-prechecks.feature
@@ -5,4 +5,3 @@ Feature: pre checks
         Given the deputy area works properly
         And the admin area works properly
         And I reset the behat SQL snapshots
-        And I save the application status into "init"

--- a/tests/behat/features/deputy/01-registration-steps/01-create-users.feature
+++ b/tests/behat/features/deputy/01-registration-steps/01-create-users.feature
@@ -48,7 +48,6 @@ Feature: deputy / user / add user
   @ndr
   Scenario: add deputy user (ndr)
     Given emails are sent from "admin" area
-    And I load the application status from "init"
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
       # assert form OK
     When I create a new "NDR-enabled" "Lay Deputy" user "John NDR" "Doe NDR" with email "behat-user-ndr@publicguardian.gov.uk" and postcode "AB12CD"

--- a/tests/behat/features/deputy/01-registration-steps/02-set-password.feature
+++ b/tests/behat/features/deputy/01-registration-steps/02-set-password.feature
@@ -1,11 +1,10 @@
 Feature: deputy / user / set password
-    
+
     @deputy
     Scenario: login and add user (deputy)
         Given emails are sent from "deputy" area
         Given I am on "/logout"
         # follow link
-        When I save the application status into "activation-link-before-opening"
         When I open the "/user/activate/" link from the email
         Then the response status code should be 200
          # empty
@@ -14,7 +13,7 @@ Feature: deputy / user / set password
         And I press "set_password_save"
         Then the form should be invalid
         #password mismatch
-        When I fill in the following: 
+        When I fill in the following:
             | set_password_password_first   | Abcd1234 |
             | set_password_password_second  | Abcd12345 |
         And I check "set_password_showTermsAndConditions"
@@ -34,20 +33,22 @@ Feature: deputy / user / set password
         When I fill in the password fields with "Abcdefgh"
         And I check "set_password_showTermsAndConditions"
         And I press "set_password_save"
-         # not agreed on TC
+        Then the form should be invalid
+        # not agreed on TC
         When I fill in the password fields with "Abcd1234"
         And I uncheck "set_password_showTermsAndConditions"
         And I press "set_password_save"
         Then the form should be invalid
         # correct !!
-        When I load the application status from "activation-link-before-opening"
-        And I activate the user with password "Abcd1234"
+        When I fill in the password fields with "Abcd1234"
+        And I check "set_password_showTermsAndConditions"
+        And I press "set_password_save"
         Then the form should be valid
         And I should see the "user-details" region
         # test login
         When I go to "logout"
         And I go to "/login"
-        And I fill in the following: 
+        And I fill in the following:
             | login_email     | behat-user@publicguardian.gov.uk |
             | login_password  | Abcd1234 |
         And I press "login_login"
@@ -69,4 +70,3 @@ Feature: deputy / user / set password
             | login_password  | Abcd1234 |
         And I press "login_login"
         Then I should not see an "#error-summary" element
-    

--- a/tests/behat/features/deputy/02-ndr/05-assets.feature
+++ b/tests/behat/features/deputy/02-ndr/05-assets.feature
@@ -162,7 +162,5 @@ Feature: NDR assets
     And each text should be present in the corresponding region:
       | 13 gold house | property-sw11-6tf-address |
     # remove property
-    When I save the application status into "ndr-report-assets-finished"
     And I click on "delete" in the "property-sw11-6tf" region
     Then I should not see the "property-sw11-6tf" region
-    And I load the application status from "ndr-report-assets-finished"

--- a/tests/behat/features/deputy/02-ndr/10-submit.feature
+++ b/tests/behat/features/deputy/02-ndr/10-submit.feature
@@ -48,7 +48,6 @@ Feature: ndr / report submit
         And I press "ndr_declaration_save"
         Then the form should be valid
         And the URL should match "/ndr/\d+/submitted"
-        And I save the application status into "ndr-after-submission"
         And the response status code should be 200
         When I save the report as "submitted NDR report"
         Then the report URL "visits-care/summary" for "submitted NDR report" should not be accessible

--- a/tests/behat/features/deputy/02-ndr/10-submit.feature
+++ b/tests/behat/features/deputy/02-ndr/10-submit.feature
@@ -14,7 +14,6 @@ Feature: ndr / report submit
         And I should see an "#expenses-section" element
         And I should see an "#action-section" element
         And I should see an "#accounts-section" element
-        And I save the application status into "ndr-before-submission"
         # assert pages not accessible
 
     @ndr

--- a/tests/behat/features/deputy/02-ndr/11-report-submission.feature
+++ b/tests/behat/features/deputy/02-ndr/11-report-submission.feature
@@ -2,8 +2,7 @@ Feature: Admin NDR submitted
 
   @ndr
   Scenario: Admin client search returns NDR client
-    Given I load the application status from "ndr-after-submission"
-    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "admin-client-search"
     Then each text should be present in the corresponding region:
     | Cly3 Hent3 | client-33333333 |

--- a/tests/behat/features/deputy/03-report/01-102/22-submit-more-documents.feature
+++ b/tests/behat/features/deputy/03-report/01-102/22-submit-more-documents.feature
@@ -31,4 +31,3 @@ Feature: Add more documents after report has been submitted
       | small.jpg        | new-document-list |
     Then I click on "confirm-submit"
     And I go to the URL previously saved as "your-reports"
-    And I save the application status into "more-documents-added"

--- a/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
+++ b/tests/behat/features/deputy/03-report/01-102/23-report-resubmission.feature
@@ -2,8 +2,7 @@ Feature: Admin unsubmit report (from client page)
 
   @deputy
   Scenario: Admin client page + search
-    Given I load the application status from "more-documents-added"
-    And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "admin-client-search"
     Then each text should be present in the corresponding region:
       | Cly Hent | client-behat001 |
@@ -26,10 +25,9 @@ Feature: Admin unsubmit report (from client page)
     # assert active report is not lsited
     But I should not see the "report-2017" region
     And I should see "25 February 2017" in the "report-2016-due-date" region
-    When I save the application status into "report-2016-pre-unsubmission"
-    And I click on "manage" in the "report-2016" region
+    When I click on "manage" in the "report-2016" region
     # unsubmit with custom due date
-    When I fill in the following:
+    And I fill in the following:
       | unsubmit_report_unsubmittedSection_0_present  | 1      |
       | unsubmit_report_unsubmittedSection_13_present | 1      |
       | unsubmit_report_dueDateChoice_4               | custom |

--- a/tests/behat/features/deputy/03-report/03-104/02-check-and-submit.feature
+++ b/tests/behat/features/deputy/03-report/03-104/02-check-and-submit.feature
@@ -13,4 +13,3 @@ Feature: Report submit
         Then the form should be valid
         And the URL should match "/report/\d+/submitted"
         And the last email should contain "next annual deputy report (for 01/01/2017 to 31/12/2017)"
-        #And I save the application status into "report-104-submitted"

--- a/tests/behat/features/deputy/03-report/03-104/03-lodging-checklist.feature
+++ b/tests/behat/features/deputy/03-report/03-104/03-lodging-checklist.feature
@@ -2,7 +2,6 @@ Feature: Admin report checklist
 
   @deputy
   Scenario: Case manager submits empty checklist for the report 104
-    #Given I load the application status from "report-104-submitted"
     Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "admin-client-search, client-detail-behat001"
     And I click on "checklist" in the "report-2016" region

--- a/tests/behat/features/deputy/04-user/03-userselfregister.feature
+++ b/tests/behat/features/deputy/04-user/03-userselfregister.feature
@@ -2,8 +2,7 @@ Feature: User Self Registration
 
   @deputy
   Scenario: A user can enter their self registration information
-    Given I load the application status from "init"
-    And I truncate the users from CASREC:
+    Given I truncate the users from CASREC:
     And emails are sent from "deputy" area
       #
       # Form all empty
@@ -153,25 +152,24 @@ Feature: User Self Registration
 
   @deputy
   Scenario: A user can self register and activate
-    Given I load the application status from "init"
-    And emails are sent from "deputy" area
+    Given emails are sent from "deputy" area
     And I add the following users to CASREC:
       | Case     | Surname      | Deputy No | Dep Surname | Dep Postcode | Typeofrep |
-      | 11112222 | Cross-Tolley | D001      | Tolley      | SW1 3RF      | OPG102    |
+      | 11112233 | Cross-Lens   | D001      | Lens      | SW1 3RF      | OPG102    |
     And I am on "/register"
     And I fill in the following:
-      | self_registration_firstname       | Zac                                     |
-      | self_registration_lastname        | Tolley                                  |
-      | self_registration_email_first     | behat-zac.tolley@digital.justice.gov.uk |
-      | self_registration_email_second    | behat-zac.tolley@digital.justice.gov.uk |
+      | self_registration_firstname       | Jenny                                     |
+      | self_registration_lastname        | Lens                                  |
+      | self_registration_email_first     | behat-jenny.lens@digital.justice.gov.uk |
+      | self_registration_email_second    | behat-jenny.lens@digital.justice.gov.uk |
       | self_registration_postcode        | SW1 3RF                                 |
       | self_registration_clientFirstname | John                                    |
-      | self_registration_clientLastname  | Cross-Tolley                            |
-      | self_registration_caseNumber      | 11112222                                |
+      | self_registration_clientLastname  | Cross-Lens                              |
+      | self_registration_caseNumber      | 11112233                                |
     And I press "self_registration_save"
     Then I should see "Please check your email"
-    And I should see "We've sent you a link to behat-zac.tolley@digital.justice.gov.uk"
-    And the last email containing a link matching "/user/activate/" should have been sent to "behat-zac.tolley@digital.justice.gov.uk"
+    And I should see "We've sent you a link to behat-jenny.lens@digital.justice.gov.uk"
+    And the last email containing a link matching "/user/activate/" should have been sent to "behat-jenny.lens@digital.justice.gov.uk"
     And I activate the user with password "Abcd1234"
     Then the URL should match "/user/details"
     When I fill in the following:
@@ -195,5 +193,5 @@ Feature: User Self Registration
     And I set the report end date to "1/1/2016"
     Then the URL should match "/lay"
     Then I go to "/logout"
-    And I am logged in as "behat-zac.tolley@digital.justice.gov.uk" with password "Abcd1234"
+    And I am logged in as "behat-jenny.lens@digital.justice.gov.uk" with password "Abcd1234"
     Then the URL should match "/lay"

--- a/tests/behat/features/deputy/04-user/06-codeputies.feature
+++ b/tests/behat/features/deputy/04-user/06-codeputies.feature
@@ -2,8 +2,7 @@ Feature: Codeputy Self Registration
 
   @deputy
   Scenario: Codeps setup
-    Given I load the application status from "init"
-    And I truncate the users from CASREC:
+    Given I truncate the users from CASREC:
     And emails are sent from "deputy" area
     Given I add the following users to CASREC:
       | Case     | Surname | Deputy No | Dep Surname | Dep Postcode | Typeofrep |

--- a/tests/behat/features/deputy/05-acl/02-pages-security.feature
+++ b/tests/behat/features/deputy/05-acl/02-pages-security.feature
@@ -39,7 +39,6 @@ Feature: deputy / acl / security on pages
   Scenario: Malicious User cannot access other's pages
     # behat-user can access report n.2
     Given I am logged in as "behat-user@publicguardian.gov.uk" with password "Abcd1234"
-    And I save the application status into "deputy-acl-before"
     Then the following "102 report" report pages should return the following status:
       | overview         | 200 |
       # decisions
@@ -55,7 +54,6 @@ Feature: deputy / acl / security on pages
     # behat-malicious CANNOT access the same URLs
     Given I am logged in as "behat-malicious@publicguardian.gov.uk" with password "Abcd1234"
     # reload the status (as some URLs calls might have deleted data)
-    And I load the application status from "deputy-acl-before"
     Then the following "102 report" report pages should return the following status:
       | overview                | 500 |
       | decisions               | 500 |
@@ -69,6 +67,5 @@ Feature: deputy / acl / security on pages
       | decisions               | 200 |
       | contacts                | 200 |
       | assets                  | 200 |
-    And I load the application status from "deputy-acl-before"
 
 

--- a/tests/behat/features/pa/01-registration-steps/00-prechecks.feature
+++ b/tests/behat/features/pa/01-registration-steps/00-prechecks.feature
@@ -2,4 +2,3 @@ Feature: PA pre checks
 
     Scenario: check app status
         Given the admin area works properly
-        And I save the application status into "init-pa"

--- a/tests/behat/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/tests/behat/features/pa/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -1,8 +1,7 @@
 Feature: Add PA users and activate PA user (journey)
 
   Scenario: add PA users
-    Given I load the application status from "init-pa"
-    And emails are sent from "admin" area
+    Given emails are sent from "admin" area
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
       # upload PA users
     When I click on "admin-upload-pa"

--- a/tests/behat/features/pa/03-report/02-common-report-sections.feature
+++ b/tests/behat/features/pa/03-report/02-common-report-sections.feature
@@ -144,4 +144,3 @@ Feature: PA user edits common report sections common to ALL report types
     # Check document removed
     And the step with the following values CAN be submitted:
       | document_wishToProvideDocumentation_0 | no |
-    And I save the application status into "102-common-sections-complete"

--- a/tests/behat/features/prof/01-registration-steps/00-prechecks.feature
+++ b/tests/behat/features/prof/01-registration-steps/00-prechecks.feature
@@ -2,4 +2,3 @@ Feature: PROF pre checks
 
     Scenario: check app status
         Given the admin area works properly
-        And I save the application status into "init-prof"

--- a/tests/behat/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
+++ b/tests/behat/features/prof/01-registration-steps/01-admin-add-pa-users-and-activate.feature
@@ -1,8 +1,7 @@
 Feature: Add PROF users and activate PROF user (journey)
 
   Scenario: add PROF users
-    Given I load the application status from "init-prof"
-    And emails are sent from "admin" area
+    Given emails are sent from "admin" area
     And I am logged in to admin as "admin@publicguardian.gov.uk" with password "Abcd1234"
       # upload PROF users
     When I click on "admin-upload-pa"

--- a/tests/behat/features/prof/03-report/02-common-report-sections.feature
+++ b/tests/behat/features/prof/03-report/02-common-report-sections.feature
@@ -156,4 +156,3 @@ Feature: PROF user edits 102-5 report sections common to ALL report types
     # Check document removed
     And the step with the following values CAN be submitted:
       | document_wishToProvideDocumentation_0 | no |
-    And I save the application status into "102-5-common-sections-complete"

--- a/tests/behat/features/prof/03-report/07-submit-report.feature
+++ b/tests/behat/features/prof/03-report/07-submit-report.feature
@@ -18,12 +18,10 @@ Feature: Report submit (client 01000010)
         Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
         And I click on "pa-report-open" in the "client-01000010" region
         Then the PROF report should be submittable
-        And I save the application status into "prof-report-completed"
 
 
     Scenario: 102-5 report declaration page
-        Given I load the application status from "prof-report-completed"
-        And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
+        Given I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
         And I click on "tab-ready"
         And I click on "pa-report-open" in the "client-01000010" region
         Then I should not see the "download-2016-report" link
@@ -87,5 +85,3 @@ Feature: Report submit (client 01000010)
             | HSBC - main account | account-01ca |
             | Current account     | account-01ca |
             | 112233              | account-01ca |
-        And I save the application status into "prof-report-submitted"
-

--- a/tests/behat/features/prof/03-report/08-lodging-checklist.feature
+++ b/tests/behat/features/prof/03-report/08-lodging-checklist.feature
@@ -1,8 +1,7 @@
 Feature: Admin report checklist
 
   Scenario: Case manager submits empty Prof checklist for the report
-    Given I load the application status from "prof-report-submitted"
-    And I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
+    Given I am logged in to admin as "casemanager@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "admin-client-search, client-detail-01000010"
     And I click on "checklist" in the "report-2016-to-2017" region
     Then the URL should match "/admin/report/\d+/checklist"

--- a/tests/behat/features/prof/07-acl.feature
+++ b/tests/behat/features/prof/07-acl.feature
@@ -46,22 +46,6 @@ Feature: PROF cannot access other's PROF's reports and clients
     And the URL "/deputyship-details/your-details/edit" should be forbidden
     And the URL "/deputyship-details/your-details/change-password" should be forbidden
 
-#  Scenario: Submitted reports cannot be viewed (overview page) or edited
-#    # load "pre-submission" status and save links
-#    Given I load the application status from "prof-report-completed"
-#    And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"
-#    When I click on "pa-report-open" in the "client-01000014" region
-#    And I save the current URL as "client-01000014-report-overview"
-#    And I click on "edit-report-period"
-#    Then the response status code should be 200
-#    # load "after submission" status and re-check the same links
-#    And I save the current URL as "client-01000014-report-completed"
-#    When I load the application status from "prof-report-submitted"
-#    When I go to the URL previously saved as "client-01000014-report-overview"
-#    Then the response status code should be 500
-#    When I go to the URL previously saved as "client-01000014-report-completed"
-#    Then the response status code should be 500
-
   Scenario: PROF_ADMIN logs in, edits own account and removes admin privilege should be logged out
     Given I load the application status from "prof-team-users-complete"
     And I am logged in as "behat-prof1@publicguardian.gov.uk" with password "Abcd1234"


### PR DESCRIPTION
## Purpose
One restriction to running the automated test suites simulataneously is that some tests save and then reload the entire database state. These sweeping changes can interrupt and break other tests running on different threads.

This PR addresses some of the more trivial instances of this behaviour, minimising its impact.

Fixes [DDPB-2657](https://opgtransform.atlassian.net/browse/DDPB-2657)

## Approach
After some extensive research on [DDPB-2623](https://opgtransform.atlassian.net/browse/DDPB-2623), several trivial instances were identified. In this PR, I removed this instances and did the small amount of cleanup necessary to keep the tests passing.

I also tidied up the `behat.yml` file, removing the unused "components" suite and removing the duplicate definition of the "admin" suite.

## Learning
[DDPB-2623](https://opgtransform.atlassian.net/browse/DDPB-2623) gives more background on this work and explains what needs to be done for the remaining tests.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes
  - N/A
