### PR TITLE
DDPB-2679: Hide Behat controller in production

### DIFF
--- a/src/AppBundle/Controller/BehatController.php
+++ b/src/AppBundle/Controller/BehatController.php
@@ -103,28 +103,4 @@ class BehatController extends AbstractController
             'recipientRole' => MailFactory::getRecipientRole($this->getUser())
         ]);
     }
-
-    /**
-     * @Route("/behat/{secret}/logs/{action}")
-     * @Template()
-     */
-    public function behatLogsResetAction(Request $request, $action)
-    {
-        $this->securityChecks($request);
-
-        $logPath = $this->getParameter('log_path');
-
-        switch ($action) {
-            case 'reset':
-                file_put_contents($logPath, "LOG RESET FROM BEHAT\n");
-                return new Response('reset OK');
-
-            case 'view':
-                $lines = array_filter(array_slice(file($logPath), -500), function ($row) {
-                    return strpos($row, 'translation.WARNING') === false;
-                });
-                $ret = implode("\n", $lines);
-                return new Response($ret);
-        }
-    }
 }

--- a/src/AppBundle/Controller/BehatController.php
+++ b/src/AppBundle/Controller/BehatController.php
@@ -16,7 +16,7 @@ class BehatController extends AbstractController
     private function securityChecks(Request $request)
     {
         if (!$this->container->getParameter('behat_controller_enabled')) {
-            return $this->createNotFoundException('Behat endpoint disabled, check the behat_controller_enabled parameter');
+            throw $this->createNotFoundException();
         }
 
         $expectedSecretParam = md5('behat-dd-' . $this->container->getParameter('secret'));

--- a/tests/behat/bootstrap/DebugTrait.php
+++ b/tests/behat/bootstrap/DebugTrait.php
@@ -13,15 +13,6 @@ trait DebugTrait
     }
 
     /**
-     * Empty behat log before each step
-     * @BeforeScenario
-     */
-    public function emptyBehatLogBeforeScenario(\Behat\Behat\Hook\Scope\BeforeScenarioScope $scope)
-    {
-        $this->visitBehatLink('logs/reset');
-    }
-
-    /**
      * @Then /^debug$/
      */
     public function debug($feature = null, $line = null)
@@ -42,8 +33,6 @@ trait DebugTrait
         //echo "- Status code: " . $session->getStatusCode() . "\n";
         $file = basename($filename);
         echo "- Response: saved into {$file} ({$bytes} bytes). View locally at https://digideps-client.local/behat-debugger.php?frame=page&f={$file} .\n";
-        $this->visitBehatLink('logs/view');
-        echo ' - Log content (scenario only): ' . $this->getSession()->getPage()->getContent();
     }
 
     /**

--- a/tests/behat/bootstrap/LinksTrait.php
+++ b/tests/behat/bootstrap/LinksTrait.php
@@ -27,9 +27,6 @@ trait LinksTrait
         }
     }
 
-    /**
-     * @Given I visit the behat link :link
-     */
     public function visitBehatLink($link)
     {
         $secret = md5('behat-dd-' . $this->getSymfonyParam('secret'));
@@ -37,9 +34,6 @@ trait LinksTrait
         $this->visit("/behat/{$secret}/{$link}");
     }
 
-    /**
-     * @Given I visit the behat admin link :link
-     */
     public function visitBehatAdminLink($link)
     {
         $secret = md5('behat-dd-' . $this->getSymfonyParam('secret'));

--- a/tests/behat/bootstrap/UserTrait.php
+++ b/tests/behat/bootstrap/UserTrait.php
@@ -56,8 +56,6 @@ trait UserTrait
             'token_date' => '-7days',
             'registration_token' => $token,
         ]);
-
-        $this->assertResponseStatus(200);
     }
 
     /**


### PR DESCRIPTION
## Purpose
The Behat controllers are used for debugging and test automation in non-production environments. However, due to a misconfiguration, they are currently available in production too.

Fixes [DDPB-2679](https://opgtransform.atlassian.net/browse/DDPB-2679)

## Approach
The controller now properly throws an exception rather than returning it (the parent function was ignoring it).

I also removed functionality which was inspecting and resetting log files. Now that log messages are put to stderr (and therefore available in CloudWatch), this functionality isn't necessary (and doesn't work).

## Learning
I considered trying to maintain the old behaviour by reading from stderr, but that's not possible in PHP. However, whilst the old behaviour is potentially convenient, I also think it's misleading and insecure.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
