### PR TITLE
DDPB-2668: Fixes performance of Document GET request by exluding the …

### DIFF
--- a/src/AppBundle/Controller/Report/DocumentController.php
+++ b/src/AppBundle/Controller/Report/DocumentController.php
@@ -339,7 +339,7 @@ class DocumentController extends AbstractController
         return $this->getRestClient()->get(
             'document/' . $documentId,
             'Report\Document',
-            ['documents', 'status', 'document-storage-reference', 'document-report-submission', 'document-report', 'report', 'report-client', 'client', 'client-users', 'user']
+            ['documents', 'status', 'document-storage-reference', 'document-report-submission', 'document-report', 'report', 'report-client', 'client', 'client-users', 'user-id']
         );
     }
 


### PR DESCRIPTION
## Purpose
Addresses bug that prevents Irwin Mitchell from removing documents

Fixes [DDPB-2668](https://opgtransform.atlassian.net/browse/DDPB-2668)

## Approach
The bug is due to the API call to `GET document/id` timing out when a Report has many users associated to it. The Doctrine code is unnecessarily hydrating dozens of fully blown User objects, when the specific request only requires the id of each user. 

The API call front the client is only used within the class I have altered, so there should be no knock on effect to removing the`user` group from the API call.

## Learning


## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [N/A] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [N/A] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [N/A] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
