### PR TITLE
DDPB-2646: Reinstate application version tag in footer

### DIFF
--- a/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
+++ b/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
@@ -132,6 +132,7 @@
             <span class="govuk-footer__licence-description">
               All content is available under the
               <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+              {% if opg_docker_tag %}<br>v {{ opg_docker_tag }}{% endif %}
             </span>
 
           </div>


### PR DESCRIPTION
## Purpose
In #1241, I inadvertently removed the application version number from the page footer. This change reinstates it.

## Approach
I just copied across the code from before.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] I have successfully built my branch to a feature environment
  - N/A
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
  - N/A
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes
  - N/A