### PR TITLE
DDPB-2646: Fix alignment of form items on admin filters

### DIFF
--- a/src/AppBundle/Resources/views/Admin/Index/index.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Index/index.html.twig
@@ -17,22 +17,21 @@
 
     {{ form_start(form, {attr: {class: 'search', novalidate: 'novalidate' }}) }}
 
-    <div class="form-group form-groups-inline flush--bottom">
+    <div class="govuk-grid-row">
         {{ form_input(form.q, 'Search', {
             'labelRaw': true,
             'labelText':'Search',
-            'inputClass': 'width-full',
-            'formGroupClass': 'width-third'}) }}
+            'inputClass': 'govuk-!-width-full',
+            'formGroupClass': 'govuk-grid-column-one-third'}) }}
 
         {{ form_select(form.role_name, '', {
             'labelText': 'Role',
-            'inputClass': 'width-full',
-            'formGroupClass': 'width-quarter'}) }}
+            'inputClass': 'govuk-!-width-full',
+            'formGroupClass': 'govuk-grid-column-one-third'}) }}
 
         {{ form_checkbox(form.ndr_enabled, '', {
             'labelText': 'NDR enabled',
-            'inputClass': 'width-full',
-            'formGroupClass': 'width-quarter'}) }}
+            'formGroupClass': 'govuk-grid-column-one-third govuk-!-margin-top-6'}) }}
     </div>
 
     <div class="form-group">

--- a/src/AppBundle/Resources/views/Components/Form/_input.html.twig
+++ b/src/AppBundle/Resources/views/Components/Form/_input.html.twig
@@ -26,7 +26,10 @@
     {{ form_errors(element) }}
 
     {% set inputType = multiline ? 'textarea' : 'input' %}
-    {% set class = element.vars.attr.class | default('') ~ ' govuk-' ~ inputType ~ ' govuk-!-width-one-half ' ~ inputClass | default('') %}
+    {% if 'govuk-!-width' not in inputClass %}
+        {% set inputClass = ' govuk-!-width-one-half' ~ inputClass %}
+    {% endif %}
+    {% set class = element.vars.attr.class | default('') ~ ' govuk-' ~ inputType ~ ' ' ~ inputClass | default('') %}
 
     {% if (preInputText is defined) and (preInputText is not empty) %}
         <span class="opg-pre-input-text">{{ preInputText }}</span>


### PR DESCRIPTION
## Purpose
Upgrading to the GOV.UK Design System caused the filters admin index page to stack vertically, wasting space.

## Approach
The issue was with incompatible GOV.UK Elements and GOV.UK Design System classes. I upgraded the CSS classes to all use the Design System.

As part of this I changed the `form_input` macro to use the `govuk-!-width-one-half` class only if no other width classes were provided in `inputClass`. Previously it was always added, which caused specificity issues.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
