### PR TITLE
Ddpb 2569 checklist unsubmitted sections

### DIFF
--- a/src/AppBundle/Controller/Admin/Client/ReportController.php
+++ b/src/AppBundle/Controller/Admin/Client/ReportController.php
@@ -91,7 +91,7 @@ class ReportController extends AbstractController
      */
     public function manageAction(Request $request, $id)
     {
-        $report = $this->getReport($id, ['report-checklist']);
+        $report = $this->getReport($id, ['report-checklist', 'action']);
         $reportDueDate = $report->getDueDate();
 
         if (!$report->getSubmitted()) {
@@ -230,7 +230,7 @@ class ReportController extends AbstractController
             array_merge(
                 self::$reportGroupsAll,
                 [
-                    'report-checklist', 'checklist-information', 'last-modified', 'user', 'previous-report-data'
+                    'report-checklist', 'checklist-information', 'last-modified', 'user', 'previous-report-data', 'action'
                 ]
             )
         );

--- a/src/AppBundle/Controller/Admin/Client/ReportController.php
+++ b/src/AppBundle/Controller/Admin/Client/ReportController.php
@@ -91,7 +91,7 @@ class ReportController extends AbstractController
      */
     public function manageAction(Request $request, $id)
     {
-        $report = $this->getReport($id, []);
+        $report = $this->getReport($id, ['report-checklist']);
         $reportDueDate = $report->getDueDate();
 
         if (!$report->getSubmitted()) {

--- a/src/AppBundle/Resources/translations/admin-checklist.en.yml
+++ b/src/AppBundle/Resources/translations/admin-checklist.en.yml
@@ -61,6 +61,9 @@ checklistPage:
     profDeputyCosts: View deputy's responses
     profDeputyCostsEstimate: View deputy's responses
   noTransferToShow: No money transfers to view
+  incompleteSubmitted: Incomplete submitted
+  dueDateSetTo: Due date set to
+  sectionsMarkedIncomplete: Sections marked incomplete
   form:
     save:
       label: Save progress

--- a/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/unsubmit_information.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Client/Report/Formatted/unsubmit_information.html.twig
@@ -1,0 +1,11 @@
+{% set translationDomain = "admin-checklist" %}
+{% trans_default_domain translationDomain %}
+
+{{ 'checklistPage.incompleteSubmitted' | trans }}: {{ report.unSubmitDate | date("j F Y") }}
+
+{{ 'checklistPage.dueDateSetTo' | trans }}: {{ report.dueDate | date("j F Y") }}
+
+{{ 'checklistPage.sectionsMarkedIncomplete' | trans }}:
+{% for section in report.unsubmittedSectionsList | split(',') %}
+    * {{ ('prevNextLinks.sections.' ~ section) | trans({}, 'report-common') }}
+{% endfor %}

--- a/src/AppBundle/Resources/views/Admin/Client/Report/checklist.html.twig
+++ b/src/AppBundle/Resources/views/Admin/Client/Report/checklist.html.twig
@@ -194,7 +194,7 @@
                     {% for info in checklist.checklistInformation %}
 
                     <tr>
-                        <td class="behat-region-information-{{ counter }}">{{ info.information | nl2br }}</td>
+                        <td class="behat-region-information-{{ counter }}">{{ info.information | nl2br | raw }}</td>
                         <td class="behat-region-information-created-by-{{ counter }} align--top">{{ info.createdBy.fullname }}, {{ info.createdBy.roleFullName }}</td>
                         <td class="behat-region-created-on-{{ counter }} numeric no-wrap align--top">{{ info.createdOn | date("j F Y") }}</td>
                     </tr>

--- a/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -107,7 +107,7 @@ Feature: Admin report checklist
     And I click on "checklist" in the "report-2016" region
     Then the URL should match "/admin/report/\d+/checklist"
     And each text should be present in the corresponding region:
-      | Not saved yet | last-saved-by |
+      | Admin User, OPG Admin | last-saved-by |
     # Begin scenario
     When I fill in "report_checklist_furtherInformationReceived" with "Some more info 1"
     When I click on "save-further-information"
@@ -118,9 +118,9 @@ Feature: Admin report checklist
       | report_checklist_furtherInformationReceived |  |
     # Assert furtherInfo table is populated
     And each text should be present in the corresponding region:
-      | Case Manager1, Case Manager | last-saved-by            |
-      | Some more info 1            | information-2            |
-      | Case Manager1, Case Manager | information-created-by-2 |
+      | Case Manager1, Case Manager | information-created-by-1 |
+      | Some more info 1            | information-1            |
+      | Case Manager1, Case Manager | information-created-by-1 |
     Then the URL should match "/admin/report/\d+/checklist"
     And I fill in "report_checklist_furtherInformationReceived" with "Some more info 2"
     When I click on "save-further-information"

--- a/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -19,8 +19,7 @@ Feature: Admin report checklist
     And I click on "checklist" in the "report-2016" region
     Then the URL should match "/admin/report/\d+/checklist"
     And each text should be present in the corresponding region:
-      | Not saved yet | last-saved-by |
-      | Not saved yet | last-modified-by |
+      | Admin User, OPG Admin | last-saved-by |
       | 1 Jan 2016 | court-date |
       | Property and affairs: general | report-type-title |
       | 1 Jan 2018 to 31 Dec 2018 | expected-date |
@@ -49,6 +48,13 @@ Feature: Admin report checklist
       | 020 3334 3555     | checklist-deputy-phone     |
       | behat-user@publicguardian.gov.uk | checklist-deputy-email |
     And I should see the "checklist-no-previous-reports" region exactly "1" times
+    # Assert furtherInfo table is populated with unsubmit information
+    And each text should be present in the corresponding region:
+      | Incomplete submitted              | information-1            |
+      | Decisions                         | information-1            |
+      | Deputy expenses                   | information-1            |
+      | Due date set to: 30 April 2022    | information-1            |
+      | Admin User, OPG Admin           | information-created-by-1   |
     # check auto-filled answers
     And the following fields should have the corresponding values:
       | report_checklist_futureSignificantDecisions_0 | yes     |
@@ -113,8 +119,8 @@ Feature: Admin report checklist
     # Assert furtherInfo table is populated
     And each text should be present in the corresponding region:
       | Case Manager1, Case Manager | last-saved-by            |
-      | Some more info 1            | information-1            |
-      | Case Manager1, Case Manager | information-created-by-1 |
+      | Some more info 1            | information-2            |
+      | Case Manager1, Case Manager | information-created-by-2 |
     Then the URL should match "/admin/report/\d+/checklist"
     And I fill in "report_checklist_furtherInformationReceived" with "Some more info 2"
     When I click on "save-further-information"

--- a/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
+++ b/tests/behat/features/deputy/03-report/01-102/24-lodging-checklist.feature
@@ -131,7 +131,6 @@ Feature: Admin report checklist
       | Some more info 2            | information-1            |
       | Case Manager1, Case Manager | information-created-by-1 |
       | Some more info 1            | information-2            |
-      | Case Manager1, Case Manager | information-created-by-2 |
     Then the URL should match "/admin/report/\d+/checklist"
 
 


### PR DESCRIPTION
## Purpose
When a report is unsubmitted, the case manager needs to know which sections were flagged for attention so that when re-visiting the checklist they dont have to go through the entire report again.

Fixes [DDPB-2569]

## Approach
The prototype requested that the information be displayed in the table that displays any additional information added tto the checklist. Rather than displaying a single template, I have persisted an entry in the checklist information table. Since this meets the design criteria and will persist even if the report is re-submitted and then a further un-submission is actioned. Thus giving a more complete history of the report.

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [n/a] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [ ] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
Lots of errors as a result of pulling in master. To be fixed elsewhere?
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes
