### PR TITLE
DDPB-2658: Adds 'Do not include deputy costs' note to Money Out section

### DIFF
--- a/src/AppBundle/Entity/Report/MoneyTransaction.php
+++ b/src/AppBundle/Entity/Report/MoneyTransaction.php
@@ -103,7 +103,15 @@ class MoneyTransaction
 
         ['deputy-security-bond', false, 'fees', 'out'],
         ['opg-fees', false, 'fees', 'out'],
-        ['professional-fees-eg-solicitor-accountant', true, 'fees', 'out'],
+        ['professional-fees-eg-solicitor-accountant-lay', true, 'fees', 'out', [User::ROLE_LAY_DEPUTY]],
+        ['professional-fees-eg-solicitor-accountant-non-lay', true, 'fees', 'out', [
+            User::ROLE_PA_NAMED,
+            User::ROLE_PA_ADMIN,
+            User::ROLE_PA_TEAM_MEMBER,
+            User::ROLE_PROF_NAMED,
+            User::ROLE_PROF_ADMIN,
+            User::ROLE_PROF_TEAM_MEMBER,
+        ]],
 
         ['investment-bonds-purchased', true, 'major-purchases', 'out'],
         ['investment-account-purchased', true, 'major-purchases', 'out'],

--- a/src/AppBundle/Entity/Report/MoneyTransaction.php
+++ b/src/AppBundle/Entity/Report/MoneyTransaction.php
@@ -103,7 +103,7 @@ class MoneyTransaction
 
         ['deputy-security-bond', false, 'fees', 'out'],
         ['opg-fees', false, 'fees', 'out'],
-        ['professional-fees-eg-solicitor-accountant-lay', true, 'fees', 'out', [User::ROLE_LAY_DEPUTY]],
+        ['professional-fees-eg-solicitor-accountant', true, 'fees', 'out', [User::ROLE_LAY_DEPUTY]],
         ['professional-fees-eg-solicitor-accountant-non-lay', true, 'fees', 'out', [
             User::ROLE_PA_NAMED,
             User::ROLE_PA_ADMIN,

--- a/src/AppBundle/Resources/translations/report-money-transaction.en.yml
+++ b/src/AppBundle/Resources/translations/report-money-transaction.en.yml
@@ -308,7 +308,7 @@ form:
       accountant-fees:
         label: Accountant's fees
       professional-fees-eg-solicitor-accountant:
-        label: Fees charged by a solicitor, accountant or other professional
+        label: Fees charged by a solicitor, accountant or other professional (Do not include deputy costs)
         moreInformations: For each fee, please enter the date, the amount and what it was for
       deputy-fees-and-expenses:
         label: Deputy fees and expenses

--- a/src/AppBundle/Resources/translations/report-money-transaction.en.yml
+++ b/src/AppBundle/Resources/translations/report-money-transaction.en.yml
@@ -307,7 +307,7 @@ form:
         label: Solicitor's fees
       accountant-fees:
         label: Accountant's fees
-      professional-fees-eg-solicitor-accountant-lay:
+      professional-fees-eg-solicitor-accountant:
         label: Fees charged by a solicitor, accountant or other professional
         moreInformations: For each fee, please enter the date, the amount and what it was for
       professional-fees-eg-solicitor-accountant-non-lay:

--- a/src/AppBundle/Resources/translations/report-money-transaction.en.yml
+++ b/src/AppBundle/Resources/translations/report-money-transaction.en.yml
@@ -307,7 +307,10 @@ form:
         label: Solicitor's fees
       accountant-fees:
         label: Accountant's fees
-      professional-fees-eg-solicitor-accountant:
+      professional-fees-eg-solicitor-accountant-lay:
+        label: Fees charged by a solicitor, accountant or other professional
+        moreInformations: For each fee, please enter the date, the amount and what it was for
+      professional-fees-eg-solicitor-accountant-non-lay:
         label: Fees charged by a solicitor, accountant or other professional (Do not include deputy costs)
         moreInformations: For each fee, please enter the date, the amount and what it was for
       deputy-fees-and-expenses:

--- a/tests/behat/features/prof/03-report/04-edit-report-sections.feature
+++ b/tests/behat/features/prof/03-report/04-edit-report-sections.feature
@@ -122,7 +122,7 @@ Feature: PROF user edits 102-5 report sections
     And I click on "edit-money_out, start"
       # add transaction n.1 and check validation
     And the step with the following values CAN be submitted:
-      | account_category_26 | professional-fees-eg-solicitor-accountant |
+      | account_category_26 | professional-fees-eg-solicitor-accountant-non-lay |
     And the step with the following values CAN be submitted:
       | account_description | prof general fees |
       | account_amount      | 50.00     |


### PR DESCRIPTION
## Purpose
Add extra copy to inform deputies not to include deputy costs in the money out section.

Fixes [DDPB-2658](https://opgtransform.atlassian.net/browse/DDPB-2658)

## Approach
One liner to the translation file.

## Learning
None.

## Checklist
- [x] I have performed a self-review of my own code
- [N/A] I have updated documentation (Confluence/GitHub wiki) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [N/A] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [ ] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [ ] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
