### PR TITLE
DDPB-2704: Upgrade `.details-banner` CSS to Design System standards

### DIFF
--- a/src/AppBundle/Resources/assets/scss/_shame.scss
+++ b/src/AppBundle/Resources/assets/scss/_shame.scss
@@ -1,10 +1,14 @@
 // Shame CSS
 // ==========================================================================
-// Quick dumping ground for exploration
-// SHOULD NOT GO TO PRODUCTION!
-/**
- * Undo the font-size overwrite in govuk-elements. It was to avoid an IE6/7 bug
- * but they're no longer supported and the overwrite made govuk-frontend unusable
- */
+
+// Undo the font-size overwrite in govuk-elements. It was to avoid an IE6/7 bug
+// but they're no longer supported and the overwrite made govuk-frontend unusable
 html { font-size: initial; }
 body { font-size: initial; }
+
+// Undo the font-weight nullification in govuk-elements. It's no longer present in
+// the Design System, but so eager that it's still cascading through.
+b,
+strong {
+    font-weight: 600;
+}

--- a/src/AppBundle/Resources/assets/scss/digideps/_details-banner.scss
+++ b/src/AppBundle/Resources/assets/scss/digideps/_details-banner.scss
@@ -2,7 +2,7 @@
 // DETAILS BANNER
 // Details banner component
 
-.opg-details-banner{
+.opg-details-banner {
     @include govuk-clearfix;
 
     display: flex;

--- a/src/AppBundle/Resources/assets/scss/digideps/_details-banner.scss
+++ b/src/AppBundle/Resources/assets/scss/digideps/_details-banner.scss
@@ -5,41 +5,25 @@
 @import 'shims';
 @import "typography";
 
-.details-banner{
+.opg-details-banner{
+    @include govuk-clearfix;
 
-  padding: 15px 0 14px;
-  border-bottom: 1px solid #bfc1c3;
-  position: relative;
+    padding: govuk-spacing(3) 0;
+    border-bottom: 1px solid $govuk-border-colour;
 
-  @extend %contain-floats;
-
-  .details-content{
-
-    float:left;
-    margin-top: 5px;
-
-    p{
-      margin: 0;
+    &__content {
+        float: left;
     }
 
-  }
 
+    &__helpline {
+        position: static;
+        float: right;
 
-  .opg-helpline {
-    position: relative;
-    float:right;
-    top:auto;
-    right: auto;
-    margin-right: 20px;
-
-    h3{
-      margin-top: 0;
-
-      @include media(desktop) {
-        @include bold-16();
-      }
+        h3 {
+            @include govuk-font(16, $weight: bold)
+        }
     }
-  }
 
 
 }

--- a/src/AppBundle/Resources/assets/scss/digideps/_details-banner.scss
+++ b/src/AppBundle/Resources/assets/scss/digideps/_details-banner.scss
@@ -2,19 +2,25 @@
 // DETAILS BANNER
 // Details banner component
 
-@import 'shims';
-@import "typography";
-
 .opg-details-banner{
     @include govuk-clearfix;
 
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
     padding: govuk-spacing(3) 0;
     border-bottom: 1px solid $govuk-border-colour;
+
+    // Combined with flex-wrap, this ensures the clearfix ::after element doesn't
+    // affect spacing of the flex elements.
+    &::after {
+        width: 100%;
+    }
 
     &__content {
         float: left;
     }
-
 
     &__helpline {
         position: static;
@@ -24,6 +30,4 @@
             @include govuk-font(16, $weight: bold)
         }
     }
-
-
 }

--- a/src/AppBundle/Resources/views/Org/ClientProfile/_detailsBanner.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/_detailsBanner.html.twig
@@ -1,13 +1,17 @@
-{% if app.user and (app.user.isDeputyProf() or app.user.isDeputyPa()) and report is defined and report.client is not null and report is not null %}
-<div class="details-banner">
-    <div class="details-content behat-region-client-details-banner">
-        <p>
-            <span class="bold">{{ 'clientName' | trans({}, 'client-profile') }} </span>{{ report.client.fullName | title }}
-            <br><span class="bold">{{ 'courtOrderNo' | trans({}, 'client-profile') }}</span> {{ report.client.caseNumber }}
-        </p>
+{% if app.user and (app.user.isDeputyProf() or app.user.isDeputyPa()) and report is defined and report is not null and report.client is not null %}
+<div class="opg-details-banner">
+    <div class="opg-details-banner__content behat-region-client-details-banner">
+        <div>
+            <strong>{{ 'clientName' | trans({}, 'client-profile') }} </strong>
+            {{ report.client.fullName | title }}
+        </div>
+        <div>
+            <strong>{{ 'courtOrderNo' | trans({}, 'client-profile') }}</strong>
+            {{ report.client.caseNumber }}
+        </div>
     </div>
     {% endif %}
-    <div class="opg-helpline">
+    <div class="opg-helpline opg-details-banner__helpline">
         <h3>Helpline<br>
             {% if not app.user %}
                 {{ 'helplineGeneral' | trans({}, 'common') }}<br/>


### PR DESCRIPTION
## Purpose
Upgrades `.details-banner` CSS to new standards

Fixes [DDPB-2704](https://opgtransform.atlassian.net/browse/DDPB-2704)

## Approach
Added a line to `_shame.scss` which makes `<strong>` and `<b>` tags render bold text as you'd expect (reversing a decision from GOV.UK Elements which will be phased out when that's deprecated).

Used flexbox for content alignment with a very simple float fallback for browsers which don't support it.

## Checklist
Deferred to #1259 