### PR TITLE
DDPB-2731: "More details" sections don't appear on PA fee and expense fields

### DIFF
--- a/src/AppBundle/Resources/assets/javascripts/modules/detailsExpander.js
+++ b/src/AppBundle/Resources/assets/javascripts/modules/detailsExpander.js
@@ -12,7 +12,7 @@
     var detailsExpander = function (containerSelector) {
         var container = $(containerSelector);
         var inputBox = container.find('input[type="text"]');
-        var textareaGroup = container.find('textarea').parents('.form-group');
+        var textareaGroup = container.find('textarea').parents('.form-group, .govuk-form-group');
 
         // more details
         inputBox.on('keyup input paste change', function (event) {


### PR DESCRIPTION
## Purpose
The `detailsExpander` module relies on the `form-group` class being used, but most pages now use the `govuk-from-group` class.

Fixes [DDPB-2731](https://opgtransform.atlassian.net/browse/DDPB-2731)

## Approach
Either class may be used. 

## Learning
In a perfect world we would use data attributes to identify the element but this is not simple due to them being created in templates.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes
