### PR TITLE
DDPB-2706: Upgrade icon CSS to Design System standards

### DIFF
--- a/src/AppBundle/Resources/assets/scss/digideps/_alert.scss
+++ b/src/AppBundle/Resources/assets/scss/digideps/_alert.scss
@@ -2,14 +2,14 @@
 // ALERT
 .opg-alert {
     @include govuk-responsive-padding(4);
-    @include govuk-responsive-margin(8, "bottom");
+    @include govuk-responsive-margin(8, 'bottom');
     @include govuk-focusable;
     max-width: 30em;
     border-left: 5px solid transparent;
 
     &__icon {
-        float: left;
         margin-right: 10px;
+        float: left;
     }
 
     &__message {
@@ -17,27 +17,27 @@
     }
 
     &--notice {
-        background-color: rgba($border-colour, .1);
+        background-color: fade-out($govuk-border-colour, .9);
     }
 
     &--success {
-        border-color: $turquoise;
-        background-color: rgba($turquoise, .1);
+        border-color: govuk-colour('turquoise');
+        background-color: fade-out(govuk-colour('turquoise'), .9);
     }
 
     &--error {
-        border-color: $error-colour;
-        background-color: rgba($error-colour, .1);
+        border-color: $govuk-error-colour;
+        background-color: fade-out($govuk-error-colour, .9);
     }
 
     &--info {
-        border-color: $light-blue;
-        background-color: rgba($light-blue, .1);
+        border-color: govuk-colour('light-blue');
+        background-color: fade-out(govuk-colour('light-blue'), .9);
     }
 
     &--important {
-        border-color: $black;
-        background-color: rgba($grey-3, .3);
+        border-color: govuk-colour('black');
+        background-color: fade-out(govuk-colour('black'), .9);
     }
 }
 

--- a/src/AppBundle/Resources/assets/scss/digideps/_icon.scss
+++ b/src/AppBundle/Resources/assets/scss/digideps/_icon.scss
@@ -1,98 +1,60 @@
 // ==========================================================================
 // ICON
 // Reusable icons
-
-.icon-plus, .opg-icon--plus {
-    @include icon(icon-plus, 24, 24, 'icons');
-    margin-right: 3px;
+.opg-icon {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
     background-size: contain;
+    vertical-align: middle;
 }
 
-.icon-notification, .opg-icon--notification {
-    @include icon(icon-notification, 22, 22, 'icons');
-    @include media(mobile) {
-        @include icon(icon-notification, 16, 16, 'icons');
-        margin-right: 6px;
-        background-size: contain;
-    }
+.icon-plus,
+.opg-icon--plus {
+    background-image: file-url('icons/icon-plus.png');
 }
 
-.icon-tick, .opg-icon--tick {
-    @include icon(icon-tick, 22, 22, 'icons');
-    @include media(mobile) {
-        @include icon(icon-tick, 16, 16, 'icons');
-        margin-right: 6px;
-        background-size: contain;
-    }
+.icon-notification,
+.opg-icon--notification {
+    background-image: file-url('icons/icon-notification.png');
 }
 
-.icon-cross, .opg-icon--cross {
-    @include icon(icon-cross, 22, 22, 'icons');
-    @include media(mobile) {
-        @include icon(icon-cross, 16, 16, 'icons');
-        margin-right: 6px;
-        background-size: contain;
-    }
+.icon-tick,
+.opg-icon--tick {
+    background-image: file-url('icons/icon-tick.png');
 }
 
-.icon-information, .opg-icon--information {
-    @include icon(icon-information, 22, 22, 'icons');
-    @include media(mobile) {
-        @include icon(icon-information, 16, 16, 'icons');
-        margin-right: 6px;
-        background-size: contain;
-    }
+.icon-cross,
+.opg-icon--cross {
+    background-image: file-url('icons/icon-cross.png');
 }
 
-.icon-important-small, .opg-icon--important-small {
-    @include icon(icon-important-small, 22, 22, 'icons');
-    @include media(mobile) {
-        @include icon(icon-important-small, 16, 16, 'icons');
-        margin-right: 6px;
-        background-size: contain;
-    }
+.icon-information,
+.opg-icon--information {
+    background-image: file-url('icons/icon-information.png');
 }
 
-.icon-loader, .opg-icon--loader {
-    width: 22px;
-    height: 22px;
-    background-image: file-url("icons/icon-loader.gif");
-    background-size: contain;
-
-    @include device-pixel-ratio() {
-      background-image: file-url("icons/icon-loader.gif");
-      background-size: 100%;
-    }
-
-    @include media(mobile) {
-        width: 16px;
-        height: 16px;
-        background-image: file-url("icons/icon-loader.gif");
-    }
+.icon-important-small,
+.opg-icon--important-small {
+    background-image: file-url('icons/icon-important-small.png');
 }
 
-.icon-pdf, .opg-icon--pdf {
-    @include icon(icon-pdf, 32, 32, 'icons');
-    margin-right: 8px;
-
-    @include media(mobile) {
-        @include icon(icon-pdf, 28, 28, 'icons');
-        margin-right: 6px;
-        background-size: contain;
-    }
-
-    // Spacing tweak for PDF icon within button-link
-    .button-link & {
-        top: 8px;
-        margin-top: -4px;
-    }
-
+.icon-loader,
+.opg-icon--loader {
+    background-image: file-url('icons/icon-loader.gif');
 }
 
-//adjusting icon within a link
-.icon {
-    a & {
-        position: relative;
-        top: 5px;
+.icon-pdf,
+.opg-icon--pdf {
+    @include govuk-media-query($until: tablet) {
+        width: 28px;
+        height: 28px;
     }
+
+    @include govuk-media-query($from: tablet) {
+        width: 32px;
+        height: 32px;
+    }
+
+    background-image: file-url('icons/icon-pdf.png');
 }

--- a/src/AppBundle/Resources/assets/scss/digideps/_icon.scss
+++ b/src/AppBundle/Resources/assets/scss/digideps/_icon.scss
@@ -56,5 +56,5 @@
         height: 32px;
     }
 
-    background-image: file-url('icons/icon-pdf.png');
+    background-image: file-url('icons/icon-pdf-2x.png');
 }

--- a/src/AppBundle/Resources/assets/scss/digideps/_icon.scss
+++ b/src/AppBundle/Resources/assets/scss/digideps/_icon.scss
@@ -1,6 +1,7 @@
 // ==========================================================================
 // ICON
 // Reusable icons
+.icon,
 .opg-icon {
     display: inline-block;
     width: 1em;

--- a/src/AppBundle/Resources/views/Macros/macros.html.twig
+++ b/src/AppBundle/Resources/views/Macros/macros.html.twig
@@ -132,6 +132,10 @@
     }) }}
 {% endmacro %}
 
+{% macro icon(type, extraClass = '') %}
+    <span class="opg-icon opg-icon--{{ type }} {{ extraClass }}"></span>
+{% endmacro %}
+
 
 {% macro notification(alertType,message) %}
     {% if alertType is defined %}

--- a/src/AppBundle/Resources/views/Macros/macros.html.twig
+++ b/src/AppBundle/Resources/views/Macros/macros.html.twig
@@ -170,6 +170,13 @@
                     {{ message | raw }}
                 </div>
             </div>
+        {% elseif alertType == 'loader' %}
+            <div class="opg-alert opg-alert--info">
+                <span class="opg-alert__icon opg-icon--loader"></span>
+                <div class="behat-region-alert-message opg-alert__message">
+                    {{ message | raw }}
+                </div>
+            </div>
         {% else %}
             <div class="opg-alert">
                 <div class="behat-region-alert-message opg-alert__message">

--- a/src/AppBundle/Resources/views/Macros/macros.html.twig
+++ b/src/AppBundle/Resources/views/Macros/macros.html.twig
@@ -141,42 +141,42 @@
     {% if alertType is defined %}
         {% if alertType == 'notice' %}
             <div class="opg-alert opg-alert--notice">
-                <span class="opg-alert__icon opg-icon--notification"></span>
+                {{ _self.icon('notification', 'opg-alert__icon') }}
                 <div class="behat-region-alert-message opg-alert__message">
                     {{ message | raw }}
                 </div>
             </div>
         {% elseif alertType == 'success' %}
             <div class="opg-alert opg-alert--success">
-                <span class="opg-alert__icon opg-icon--tick"></span>
+                {{ _self.icon('tick', 'opg-alert__icon') }}
                 <div class="behat-region-alert-message opg-alert__message">
                     {{ message | raw }}
                 </div>
             </div>
         {% elseif alertType == 'error' %}
             <div class="opg-alert opg-alert--error">
-                <span class="opg-alert__icon opg-icon--cross"></span>
+                {{ _self.icon('cross', 'opg-alert__icon') }}
                 <div class="behat-region-alert-message opg-alert__message">
                     {{ message | raw }}
                 </div>
             </div>
         {% elseif alertType == 'info' %}
             <div class="opg-alert opg-alert--info">
-                <span class="opg-alert__icon opg-icon--information"></span>
+                {{ _self.icon('information', 'opg-alert__icon') }}
                 <div class="behat-region-alert-message opg-alert__message">
                     {{ message | raw }}
                 </div>
             </div>
         {% elseif alertType == 'important' %}
             <div class="opg-alert opg-alert--important">
-                <span class="opg-alert__icon opg-icon--important-small"></span>
+                {{ _self.icon('important-small', 'opg-alert__icon') }}
                 <div class="behat-region-alert-message opg-alert__message">
                     {{ message | raw }}
                 </div>
             </div>
         {% elseif alertType == 'loader' %}
             <div class="opg-alert opg-alert--info">
-                <span class="opg-alert__icon opg-icon--loader"></span>
+                {{ _self.icon('loader', 'opg-alert__icon') }}
                 <div class="behat-region-alert-message opg-alert__message">
                     {{ message | raw }}
                 </div>

--- a/src/AppBundle/Resources/views/Report/Balance/balance.html.twig
+++ b/src/AppBundle/Resources/views/Report/Balance/balance.html.twig
@@ -19,40 +19,25 @@
 
 {% block pageContent %}
     {% if not readyToBalance %}
-        <div class="alert-info panel panel-border-narrow" id="alert-not-started">
-            <span class="icon icon-information"></span>
-            <div class="alert-message">
-                <p>
-                    {{ ('alerts.notStarted' ~ app.user.getRoleForTrans) | trans(transOptions) }}
-                </p>
-            </div>
-        </div>
+        {{ macros.notification('info', ('alerts.notStarted' ~ app.user.getRoleForTrans) | trans(transOptions)) }}
     {% else %}
         {% if report.isTotalsMatch %}
-            <div class="alert-success panel panel-border-narrow" id="alert-balanced">
-                <span class="icon icon-tick"></span>
-                <div class="alert-message">
-                    <p class="bold">{{ 'alerts.balanced' | trans }}</p>
-                </div>
-            </div>
+            {{ macros.notification('success', 'alerts.balanced' | trans) }}
         {% else %}
-            <div class="alert{% if report.isDue %}-error{% endif %} panel panel-border-narrow behat-region-balance-bad"
-                 id="alert-not-balanced">
-                {% if report.isDue %}
-                    <span class="icon icon-cross"></span>
-                {% endif %}
-                <div class="alert-message">
+            {% set alertMessage %}
+                <div class="behat-region-balance-bad">
                     {% if report.isDue %}
-                        <p class="bold">{{ 'alerts.notBalanced' | trans }}</p>
+                        <h3 class="govuk-heading-m">{{ 'alerts.notBalanced' | trans }}</h3>
                     {% endif %}
                     <div class="data behat-region-unaccounted-for">
-                        <span class="data-item bold-xlarge">
+                        <span class="govuk-heading-xl govuk-!-margin-bottom-0">
                             £{{ report.totalsOffset | abs | money_format }}
                         </span>
-                        <span class="data-item bold-xsmall">{{ 'alerts.notBalancedSupport' | trans(transOptions) }}</span>
+                        {{ 'alerts.notBalancedSupport' | trans(transOptions) }}
                     </div>
                 </div>
-            </div>
+            {% endset %}
+            {{ macros.notification(report.isDue ? 'error' : 'notice', alertMessage) }}
         {% endif %}
     {% endif %}
 

--- a/src/AppBundle/Resources/views/Report/BankAccount/deleteConfirm.html.twig
+++ b/src/AppBundle/Resources/views/Report/BankAccount/deleteConfirm.html.twig
@@ -46,20 +46,19 @@
         </tbody>
     </table>
 
-    <div class="alert-important panel panel-border-narrow push--bottom">
-        <span class="icon icon-important-small"></span>
-        <div class="alert-message">
-            <p>
-                You have
-                {% set count, total = 1, (dp.transactionsCount) %}
-                {% for key,transaction in dp.transactions %}
-                    {% if transaction > 0 %}{{ key | trans({},'common') | lower  }}{% if count == (total-1) %} and {% elseif count < total %}, {% endif %}
-                        {% set count = count + 1 %}
-                    {% endif %}
-                {% endfor %}
-                payments linked to this bank account. If you remove the account, we'll unlink the payments for you.</p>
-        </div>
-    </div>
+    {% set alertMessage %}
+        You have
+        {% set count, total = 1, (dp.transactionsCount) %}
+        {% for key,transaction in dp.transactions %}
+            {% if transaction > 0 %}
+                {{ key | trans({},'common') | lower  }}
+                {% if count == (total-1) %} and {% elseif count < total %}, {% endif %}
+                {% set count = count + 1 %}
+            {% endif %}
+        {% endfor %}
+        payments linked to this bank account. If you remove the account, we'll unlink the payments for you.
+    {% endset %}
+    {{ macros.notification('important', alertMessage) }}
 
     <a href="{{ path('bank_account_delete', { reportId: report.id, 'accountId': accountId, 'confirm': 1 }) }}" class="button push-half--right behat-link-confirm">{{ 'deletePage.linkButtonLabel' | trans }}</a>
 

--- a/src/AppBundle/Resources/views/Report/Document/step2.html.twig
+++ b/src/AppBundle/Resources/views/Report/Document/step2.html.twig
@@ -38,21 +38,18 @@
 
     <h2 class="heading-medium flush--top">{{ (page ~ '.uploadHeading') | trans }}</h2>
 
-    <div class="alert-info panel panel-border-narrow js-hidden">
-        <span class="icon icon-information"></span>
-        <div class="alert-message">
-            <p>{{ (page ~ '.uploadHint') | trans }}</p>
-        </div>
+    <div class="js-hidden">
+        {{ macros.notification('info', (page ~ '.uploadHint') | trans) }}
     </div>
 
     {{ form_submit(form.save, '', {'buttonClass': 'behat-link-attach-file js-uploading', 'labelText': 'form.submitButton' | trans}) }}
 
-    <div class="alert-info panel panel-border-narrow push-half--top hidden" id="upload-progress">
-        <span class="icon icon-loader"></span>
-        <div class="alert-message">
-            <p>{{ (page ~ '.pleaseWait') | trans }}</p>
-            <p>{{ (page ~ '.uploadHint') | trans }}</p>
-        </div>
+    {% set alertMessage %}
+        <p>{{ (page ~ '.pleaseWait') | trans }}</p>
+        <p>{{ (page ~ '.uploadHint') | trans }}</p>
+    {% endset %}
+    <div id="upload-progress" class="hidden">
+        {{ macros.notification('loader', alertMessage) }}
     </div>
 
     {{ form_end(form) }}

--- a/src/AppBundle/Resources/views/Report/MoneyInShort/start.html.twig
+++ b/src/AppBundle/Resources/views/Report/MoneyInShort/start.html.twig
@@ -13,12 +13,7 @@
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block notification %}
-    <div class="push--top">
-        <div class="alert-info panel panel-border-narrow">
-            <span class="icon icon-information"></span>
-            <div class="alert-message"><p>{{ 'startPage.notification' | trans }}</p></div>
-        </div>
-    </div>
+    {{ macros.notification('info', 'startPage.notification' | trans)}}
 {% endblock %}
 
 {% block pageContent %}

--- a/src/AppBundle/Resources/views/Report/MoneyOutShort/start.html.twig
+++ b/src/AppBundle/Resources/views/Report/MoneyOutShort/start.html.twig
@@ -13,12 +13,7 @@
 {% block breadcrumbs %}{{ macros.breadcrumbs(report) }}{% endblock %}
 
 {% block notification %}
-    <div class="push--top">
-        <div class="alert-info panel panel-border-narrow">
-            <span class="icon icon-information"></span>
-            <div class="alert-message"><p>{{ 'startPage.notification' | trans }}</p></div>
-        </div>
-    </div>
+    {{ macros.notification('info', 'startPage.notification' | trans)}}
 {% endblock %}
 
 {% block pageContent %}


### PR DESCRIPTION
## Purpose
Upgrade icon CSS to Design System standards

Fixes [DDPB-2706](https://opgtransform.atlassian.net/browse/DDPB-2706)

## Approach
Simplified icon CSS and renamed to `.opg-icon` class (but left old class in place to support remaining icons)

Created an icon macro for easier reuse/management

Tided up alerts CSS

Used the notification macro in place of all remaining hand-coded alerts

## Checklist
Deferred to #1259