### PR TITLE
DDBP-2697 Remove half width class from textarea input macro

### DIFF
--- a/src/AppBundle/Resources/views/Components/Form/_input.html.twig
+++ b/src/AppBundle/Resources/views/Components/Form/_input.html.twig
@@ -26,6 +26,9 @@
     {{ form_errors(element) }}
 
     {% set inputType = multiline ? 'textarea' : 'input' %}
+    {% if 'govuk-!-width' not in inputClass %}
+        {% set inputClass = ' govuk-!-width-one-half ' ~ inputClass %}
+    {% endif %}
     {% set class = element.vars.attr.class | default('') ~ ' govuk-' ~ inputType ~ ' ' ~ inputClass | default('') %}
 
     {% if (preInputText is defined) and (preInputText is not empty) %}
@@ -40,6 +43,7 @@
         {{ form_widget(element, {
             'attr': {
                 'class': class,
+                'rows': '5',
                 'aria-describedby': element.vars.id ~ '-hint',
             }
         }) }}
@@ -48,6 +52,7 @@
             'attr': {
                 'class': class ~ ' govuk-' ~ inputType ~ '--error',
                 'aria-invalid': 'true',
+                'rows': '5',
                 'aria-describedby': element.vars.id ~ '-hint ' ~ element.vars.id ~ '-error',
             }
         }) }}

--- a/src/AppBundle/Resources/views/Components/Form/_input.html.twig
+++ b/src/AppBundle/Resources/views/Components/Form/_input.html.twig
@@ -26,9 +26,6 @@
     {{ form_errors(element) }}
 
     {% set inputType = multiline ? 'textarea' : 'input' %}
-    {% if 'govuk-!-width' not in inputClass %}
-        {% set inputClass = ' govuk-!-width-one-half ' ~ inputClass %}
-    {% endif %}
     {% set class = element.vars.attr.class | default('') ~ ' govuk-' ~ inputType ~ ' ' ~ inputClass | default('') %}
 
     {% if (preInputText is defined) and (preInputText is not empty) %}


### PR DESCRIPTION
## Purpose
Textarea inputs were only displaying at half size since updating to the new GOV UK styles. We needed them to be full-width to encourage more feedback from users.

Fixes [DDPB-2697](https://opgtransform.atlassian.net/browse/DDPB-2697?atlOrigin=eyJpIjoiNjI3ZWFhZWM2YzBjNGE0MWI2MjYzODM5MWRiYWQ4NjIiLCJwIjoiaiJ9)
## Approach
I found out which macro was creating the inputs, then edited the set up to remove the half-width class

## Learning
I used the [GOV UK design systems](https://design-system.service.gov.uk/components/textarea/) to see how they format the textarea example and followed their lead with 5 rows

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [ ] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [ ] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [ ] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
