### PR TITLE
DDPB-2743: Update Behat tests to add PA expenses

### DIFF
--- a/tests/behat/features/pa/03-report/03-edit-report-sections.feature
+++ b/tests/behat/features/pa/03-report/03-edit-report-sections.feature
@@ -1,6 +1,6 @@
 Feature: PA user edits report sections
 
-  Scenario: PA 102 deputy expenses (No fees exist)
+  Scenario: PA 102 deputy expenses (with fees)
     Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"
     And I click on "pa-report-open" in the "client-01000014" region
     And I click on "edit-pa_fee_expense, start"
@@ -10,16 +10,24 @@ Feature: PA user edits report sections
       | fee_exist_hasFees_1 | no |
     Given the step cannot be submitted without making a selection
     And the step with the following values CAN be submitted:
-      | fee_exist_reasonForNoFees | Some reason for no fees|
+      | fee_exist_reasonForNoFees | Some reason for no fees |
     # "Fees outside practice direction" question
     Given the step cannot be submitted without making a selection
     And the step with the following values CAN be submitted:
-      | yes_no_paidForAnything_1 | no |
+      | yes_no_paidForAnything_1 | yes |
+    And the step cannot be submitted without making a selection
+    And the step with the following values CAN be submitted:
+      | expenses_single_explanation | Some expense |
+      | expenses_single_amount | 14.00 |
+    And I fill in "add_another_addAnother_1" with "no"
+    And I click on "save-and-continue"
     # check record in summary page
     And each text should be present in the corresponding region:
-      | no                            | no-contacts        |
-      | Some reason for no fees       | reason-no-fees     |
-      | no                            | paid-for-anything  |
+      | no                            | has-fees             |
+      | Some reason for no fees       | reason-no-fees       |
+      | yes                           | paid-for-anything    |
+      | Some expense                  | expense-some-expense |
+      | £14.00                        | expense-some-expense |
 
   Scenario: PA 102 gifts
     Given I am logged in as "behat-pa1@publicguardian.gov.uk" with password "Abcd1234"

--- a/tests/behat/features/pa/03-report/03-edit-report-sections.feature
+++ b/tests/behat/features/pa/03-report/03-edit-report-sections.feature
@@ -142,7 +142,7 @@ Feature: PA user edits report sections
     And I select "HSBC - main account - Current account (****01ca)" from "account_bankAccountId"
     And the step with the following values CAN be submitted:
       | account_description | pension received |
-      | account_amount      | 50.00         |
+      | account_amount      | 64.00         |
     # add another: no
     And I choose "no" when asked for adding another record
     # check record in summary page


### PR DESCRIPTION
## Purpose
The "PA deputy fees and expenses" section is only available to PA deputies. In Behat we explicitly test this section, whereas other sections are tested in professional and lay suites.

However, the Behat tests do not add any expenses. This means that not every part of the section is tested. As a result, a recent issue introduced by the PHP7 upgrade was not picked up by tests.

Fixes [DDPB-2743](https://opgtransform.atlassian.net/browse/DDPB-2743)

## Approach
I updated the fees and expenses tests to add a new expense. I also updated the "money in" amount so that the accounts would balance and the report could be submitted.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
  - N/A
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes
  - N/A: only changes to tests
