### PR TITLE
DDPB-2735: Remove explicit dependency on egulias/email-validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "phpunit/phpunit": "^4.8.36",
         "snc/redis-bundle": "^2.1.9",
         "predis/predis": "^1.1.1",
-        "egulias/email-validator": "^1.2.14",
         "aws/aws-sdk-php": "^3.100.9"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af45130bfc6c0981853a062988b31821",
+    "content-hash": "6857f7a24a7456356d35a4fdf7d3236b",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -1425,58 +1425,6 @@
                 "reflection"
             ],
             "time": "2018-06-14T14:45:07+00:00"
-        },
-        {
-            "name": "egulias/email-validator",
-            "version": "1.2.15",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "758a77525bdaabd6c0f5669176bd4361cb2dda9e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/758a77525bdaabd6c0f5669176bd4361cb2dda9e",
-                "reference": "758a77525bdaabd6c0f5669176bd4361cb2dda9e",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "^1.0.1",
-                "php": ">= 5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.24"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Egulias\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Eduardo Gulias Davis"
-                }
-            ],
-            "description": "A library for validating emails",
-            "homepage": "https://github.com/egulias/EmailValidator",
-            "keywords": [
-                "email",
-                "emailvalidation",
-                "emailvalidator",
-                "validation",
-                "validator"
-            ],
-            "time": "2018-09-25T20:59:41+00:00"
         },
         {
             "name": "fabpot/goutte",


### PR DESCRIPTION
## Purpose
We have the library `egulias/email-validator` listed in our Composer dependencies but we don't actually use it. Instead, we do email validation through Symfony (which, in turn, _does_ use this package).

I suspect it was incorrectly installed as a test before identifying the Symfony-based solution.

Fixes [DDPB-2735](https://opgtransform.atlassian.net/browse/DDPB-2735)

## Approach
I removed the dependency.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
  - N/A
- [x] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes
  - N/A
