### PR TITLE
DDPB-2750: Only add details banner class for non-lay deputies

### DIFF
--- a/src/AppBundle/Resources/views/Org/ClientProfile/_detailsBanner.html.twig
+++ b/src/AppBundle/Resources/views/Org/ClientProfile/_detailsBanner.html.twig
@@ -1,5 +1,11 @@
 {% if app.user and (app.user.isDeputyProf() or app.user.isDeputyPa()) and report is defined and report is not null
    and report.client is not null %}
+   {% set showDetailsBanner = true %}
+{% else %}
+    {% set showDetailsBanner = false %}
+{% endif %}
+
+{% if showDetailsBanner %}
 <div class="opg-details-banner">
     <div class="opg-details-banner__content behat-region-client-details-banner">
         <div>
@@ -12,7 +18,7 @@
         </div>
     </div>
     {% endif %}
-    <div class="opg-helpline opg-details-banner__helpline">
+    <div class="opg-helpline {% if showDetailsBanner %}opg-details-banner__helpline{% endif %}">
         <h3>Helpline<br>
             {% if not app.user %}
                 {{ 'helplineGeneral' | trans({}, 'common') }}<br/>
@@ -29,7 +35,6 @@
             {% endif %}
         </h3>
     </div>
-{% if app.user and (app.user.isDeputyProf() or app.user.isDeputyPa()) and report is defined and report is not null
-   and report.client is not null %}
+{% if showDetailsBanner %}
 </div>
 {% endif %}


### PR DESCRIPTION
## Purpose
DDPB-2673 introduced a slight regression to the helpline box for lay deputies. This is because it is being given an additional CSS class which aligns and sizes it as for PA and Professional deputies. It's unlikely this would be noticed by any users, but in certain situations it pushes header down just a bit too far.

Fixes [DDPB-2750](https://opgtransform.atlassian.net/browse/DDPB-2750)

## Approach
I only included the class for non-lay reports. I used the existing if statement, but used a temporary variable to stop us calling it three times.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes
  -  N/A
