### PR TITLE
DDPB-2751 ensure email is lowercase to match database. Amended behat …

### DIFF
--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -406,7 +406,7 @@ class User implements AdvancedUserInterface
      */
     public function getEmail()
     {
-        return $this->email;
+        return strtolower($this->email);
     }
 
     /**

--- a/tests/behat/features/deputy/04-user/01-reset-password.feature
+++ b/tests/behat/features/deputy/04-user/01-reset-password.feature
@@ -25,7 +25,7 @@ Feature: deputy / password reset
       # existing email (email is now sent)
       When I go to "/login"
       And I click on "forgotten-password"
-      And I fill in "password_forgotten_email" with "behat-user@publicguardian.gov.uk"
+      And I fill in "password_forgotten_email" with "BEHAT-UsEr@publicguardian.gov.uk"
       And I press "password_forgotten_submit"
       Then the form should be valid
       And I click on "return-to-login"


### PR DESCRIPTION
## Purpose
Ensure password reset works with both upper and lower case input.

Fixes [DDPB-2751](https://opgtransform.atlassian.net/browse/DDPB-2751)

## Approach
strtolower email in User entity when requesting email, in case any database entries are in upper case, and changed api call to reset token with lower case email

## Learning

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
** found 78 high severity vulnerabilities in 7310 scanned packages ** Handled in DDPB-2769
- [ ] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes
