### PR TITLE
DDPB-2752: Fixes broken error message on registration page

### DIFF
--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -267,10 +267,7 @@ class UserController extends AbstractController
 
                     case 422:
                         $form->addError(new FormError(
-                            $translator->trans('email.first.existingError', [
-                                '%login%' => $this->generateUrl('login'),
-                                '%passwordForgotten%' => $this->generateUrl('password_forgotten')
-                            ], 'register')));
+                            $translator->trans('email.first.existingError', [], 'register')));
                         break;
 
                     case 400:

--- a/src/AppBundle/Resources/translations/register.en.yml
+++ b/src/AppBundle/Resources/translations/register.en.yml
@@ -19,7 +19,7 @@ email:
       label: "Your email"
       hint: ""
       existingError: |
-        This email address has already been registered. Please sign in or reset your password.
+        This email address has already been registered.
       invalid: Enter a valid email address
     second:
       label: "Confirm your email"

--- a/src/AppBundle/Resources/translations/register.en.yml
+++ b/src/AppBundle/Resources/translations/register.en.yml
@@ -19,7 +19,7 @@ email:
       label: "Your email"
       hint: ""
       existingError: |
-        This email address has already been registered. Please <a href="%login%">sign in</a> or <a href="%passwordForgotten%">reset your password</a>.
+        This email address has already been registered. Please sign in or reset your password.
       invalid: Enter a valid email address
     second:
       label: "Confirm your email"


### PR DESCRIPTION
## Purpose
The error message was attempting to display a link to the "sign in" and "reset your password" pages.

Fixes [DDPB-2752](https://opgtransform.atlassian.net/browse/DDPB-2752)

## Approach
The simplest fix (and what I have implemented) is to remove the links, and just offer the text. 

It's not a simple case of adding the `raw` tag as the error text markup is constructed using the generic `_validation-summary.html.twig`, And applying `raw` to every error output is unsafe. Also, if a workaround was found to apply `raw` just in this scenario, the CSS styling of the link is inherited such that the link is red, so further work would be required to fix that.

The scenario for viewing this error in the first place is edge case as it is, and the text even without links seems sufficient enough to aid the user. There is a "sign up" link below the message in any case.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have updated documentation (Confluence/GitHub wiki) where relevant
- [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [ ] I have successfully built my branch to a feature environment
- [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [ ] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [ ] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [ ] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes

### For each page changed
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
