### PR TITLE
Add technical debt document

### DIFF
--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ _Any tips and tricks, blog posts or tools which helped you. Plus anything notabl
 
 ## Checklist
 - [ ] I have performed a self-review of my own code
-- [ ] I have updated documentation (Confluence/GitHub wiki) where relevant
+- [ ] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
 - [ ] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
 - [ ] I have successfully built my branch to a feature environment
 - [ ] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -1,0 +1,10 @@
+# Technical debt
+
+A log of technical debt we're aware of and have accepted. These aren't "problems", but we might like to address them in the future if we have suitable time and resource, if related work gives an opportunity, or if they become more pressing.
+
+- There are several files and folders we don't use any more which can be safely removed
+- We should use environment variables as feature switches, rather than having separate config files/envtrypoints for each environment
+- We don't need to generate `behat.yml` or `parameters.yml` through confd. We should use environment variables to populate them instead, deobfuscating our code.
+- We define status label translations in `common.en.yml` (twice), `ndr-overview.en.yml` (twice) and `report-overview.en.yml` (twice). Using one, clear definition would make it easier to make changes in the future
+- We should use `bin/phpunit` when running tests (instead of `vendor/phpunit/phpunit/phpunit`)
+- `behat-debugger.php` is a poor way of dealing with test failures: it requires explicit setup in our NGINX configuration files and doesn't always collect useful information (e.g. just showing "Application error" when something crashes)

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -4,6 +4,7 @@ A log of technical debt we're aware of and have accepted. These aren't "problems
 
 - There are several files and folders we don't use any more which can be safely removed
 - We should use environment variables as feature switches, rather than having separate config files/envtrypoints for each environment
+- The environment variable `env` is poorly named. It distinguishes between the public and admin sites, so should be called something like `subsite` for clarity. Similarly, the values (currently "admin" and "prod") could be improved to be clearer.
 - We don't need to generate `behat.yml` or `parameters.yml` through confd. We should use environment variables to populate them instead, deobfuscating our code.
 - We define status label translations in `common.en.yml` (twice), `ndr-overview.en.yml` (twice) and `report-overview.en.yml` (twice). Using one, clear definition would make it easier to make changes in the future
 - We should use `bin/phpunit` when running tests (instead of `vendor/phpunit/phpunit/phpunit`)

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -4,7 +4,7 @@ A log of technical debt we're aware of and have accepted. These aren't "problems
 
 - There are several files and folders we don't use any more which can be safely removed
 - We should use environment variables as feature switches, rather than having separate config files/envtrypoints for each environment
-- The environment variable `env` is poorly named. It distinguishes between the public and admin sites, so should be called something like `subsite` for clarity. Similarly, the values (currently "admin" and "prod") could be improved to be clearer.
+- The environment variable `env` is poorly named. It distinguishes between the public and admin sites, so should be called something like `subsite` for clarity. Similarly, the values (currently "admin" and "front") could be improved to be clearer.
 - We don't need to generate `behat.yml` or `parameters.yml` through confd. We should use environment variables to populate them instead, deobfuscating our code.
 - We define status label translations in `common.en.yml` (twice), `ndr-overview.en.yml` (twice) and `report-overview.en.yml` (twice). Using one, clear definition would make it easier to make changes in the future
 - We should use `bin/phpunit` when running tests (instead of `vendor/phpunit/phpunit/phpunit`)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -41,4 +41,10 @@ The Behat tests are divided into 6 suites:
 - `prof`: Tests for professional deputy user functionality.
 - `pa`: Tests for public authority deputy user functionality.
 
+## Emails in non-production environments
+
+Non-production environments don't send emails to avoid data leakage, confusion and embarassment. Instead, email is sent to a mock service which stores it for future reference. You can access the emails stored by the mock service at `/behat/emails` in any non-production environment.
+
+Note that the public-facing frontend and the administration area have separate email stores (both accessible at `/behat/emails` of the relevant service URL).
+
 [mockery]: http://docs.mockery.io/en/latest/


### PR DESCRIPTION
## Purpose
We want to record known technical debt in DigiDeps.

## Approach
I created a document to record tech debt (and [another in API](https://github.com/ministryofjustice/opg-digi-deps-api/pull/569)). I also added it as a documentation option in our PR template.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki) where relevant
