### PR TITLE
DDPD-2775: Fix font scaling in Internet Explorer

### DIFF
--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -9,3 +9,4 @@ A log of technical debt we're aware of and have accepted. These aren't "problems
 - We define status label translations in `common.en.yml` (twice), `ndr-overview.en.yml` (twice) and `report-overview.en.yml` (twice). Using one, clear definition would make it easier to make changes in the future
 - We should use `bin/phpunit` when running tests (instead of `vendor/phpunit/phpunit/phpunit`)
 - `behat-debugger.php` is a poor way of dealing with test failures: it requires explicit setup in our NGINX configuration files and doesn't always collect useful information (e.g. just showing "Application error" when something crashes)
+- We should move Composer and NPM into separate containers so we can mount the vendor/assets folders first then build onto both the host and container (see DDPB-2732)

--- a/src/AppBundle/Resources/assets/scss/_shame.scss
+++ b/src/AppBundle/Resources/assets/scss/_shame.scss
@@ -3,8 +3,8 @@
 
 // Undo the font-size overwrite in govuk-elements. It was to avoid an IE6/7 bug
 // but they're no longer supported and the overwrite made govuk-frontend unusable
-html { font-size: initial; }
-body { font-size: initial; }
+html { font-size: 100%; }
+body { font-size: 100%; }
 
 // Undo the font-weight nullification in govuk-elements. It's no longer present in
 // the Design System, but so eager that it's still cascading through.


### PR DESCRIPTION
## Purpose
When introducing the GOV.UK Design System, we had to put in a fix for scaling issues caused by combining it with GOV.UK Elements. We did so by resetting the html and body font size to `initial`.

However, Internet Explorer does not support the `initial` keyword.

Fixes [DDPB-2775](https://opgtransform.atlassian.net/browse/DDPB-2775)

## Approach
I instead used the value `100%`, which does the same thing and _is_ supported by Internet Explorer. It's just a bit less elegant.

## Learning
I had to get a [Internet Explorer virtual machine](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/) to verify the problem and the fix.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes

### For each page changed
All N/A
