### PR TITLE
DDPB-2789: Deprecate GOV.UK Frontend Template

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -85,29 +85,15 @@ const buildApplicationCSSFromSass = () => { // Compile sass files, uglify, copy
         .pipe(gulp.dest(config.webAssets + '/stylesheets'));
 };
 
-const makeImagePathsAbsoluteInGovUKCSSThenCopy = () => {
-    return gulp.src([
-            './node_modules/govuk_template_mustache/assets/stylesheets/fonts.css',
-            './node_modules/govuk_template_mustache/assets/stylesheets/govuk-template.css',
-        ])
-        .pipe(replace('images/', '/images/'))
-        .pipe(gulp.dest(config.webAssets + '/stylesheets'));
-}
-
-const copyGovUKAssets = () => {
-    return gulp.src('node_modules/govuk-frontend/assets/**/*')
-        .pipe(gulp.dest(config.webAssets + '/stylesheets'));
-}
 const copyGovUKFonts = () => {
-    return gulp.src('node_modules/govuk_template_mustache/assets/stylesheets/fonts/*')
+    return gulp.src('node_modules/govuk-frontend/assets/fonts/*')
         .pipe(gulp.dest(config.webAssets + '/stylesheets/fonts'));
 }
+
 const copyAllImages = () => {
     return gulp.src([
             './node_modules/govuk_frontend_toolkit/images/**/*',
-            './node_modules/govuk_template_mustache/assets/images/*',
-            './node_modules/govuk_template_mustache/assets/stylesheets/images/**/*',
-            './node_modules/govuk_template_mustache/assets/stylesheets/images/gov.uk_logotype_crown.png',
+            './node_modules/govuk-frontend/assets/images/*',
             config.imgSrc + '/**/*'
         ])
         .pipe(gulp.dest('./web/images'));
@@ -116,7 +102,6 @@ const copyAllImages = () => {
 const concatJSThenMinifyAndCopy = () => { // Only minify if prod
     return gulp.src([
             './node_modules/govuk-frontend/all.js',
-            './node_modules/govuk_template_mustache/assets/javascripts/govuk-template.js',
             './node_modules/govuk_frontend_toolkit/javascripts/govuk/show-hide-content.js',
             config.jsSrc + '/govuk/polyfill/*.js',
             config.jsSrc + '/modules/*.js',
@@ -157,9 +142,7 @@ gulp.task('default', gulp.series(
     cleanAssets,
     gulp.parallel(
         'sass',
-        makeImagePathsAbsoluteInGovUKCSSThenCopy,
         copyAllImages,
-        copyGovUKAssets,
         copyGovUKFonts,
         'app-js',
         copyJQuery,

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -75,9 +75,7 @@ const deleteFormattedReportCSSVersion = () => {
 }
 
 const buildApplicationCSSFromSass = () => { // Compile sass files, uglify, copy
-    return gulp.src([
-        config.sassSrc + '/application.scss',
-        config.sassSrc + '/application-print.scss'])
+    return gulp.src(config.sassSrc + '/application.scss')
         .pipe(sourcemaps.init())
         .pipe(sass(config.sass).on('error', sass.logError))
         .pipe(uglifycss())

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -100,8 +100,6 @@ const copyAllImages = () => {
 const concatJSThenMinifyAndCopy = () => { // Only minify if prod
     return gulp.src([
             './node_modules/govuk-frontend/all.js',
-            './node_modules/govuk_frontend_toolkit/javascripts/govuk/show-hide-content.js',
-            config.jsSrc + '/govuk/polyfill/*.js',
             config.jsSrc + '/modules/*.js',
             config.jsSrc + '/main.js'])
         .pipe(sourcemaps.init())

--- a/package-lock.json
+++ b/package-lock.json
@@ -3034,12 +3034,6 @@
       "integrity": "sha1-sJpgYxr7ukv6x2qLfALnJBnCnPU=",
       "dev": true
     },
-    "govuk_template_mustache": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/govuk_template_mustache/-/govuk_template_mustache-0.24.1.tgz",
-      "integrity": "sha1-RiTiuePM26eKRolWhxPth6s/BVo=",
-      "dev": true
-    },
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "devDependencies": {
     "del": "^3.0.0",
     "govuk-elements-sass": "^3.1.0",
-    "govuk_template_mustache": "^0.24.0",
     "gulp": "^4.0.0",
     "gulp-concat": "^2.6.1",
     "gulp-jshint": "^2.1.0",

--- a/src/AppBundle/Resources/assets/javascripts/modules/show-hide-content.js
+++ b/src/AppBundle/Resources/assets/javascripts/modules/show-hide-content.js
@@ -1,0 +1,172 @@
+(function (global) {
+  'use strict'
+
+  var $ = window.jQuery
+  var GOVUK = window.GOVUK || {}
+
+  function ShowHideContent () {
+    var self = this
+
+    // Radio and Checkbox selectors
+    var selectors = {
+      namespace: 'ShowHideContent',
+      radio: '[data-target] > input[type="radio"]',
+      checkbox: '[data-target] > input[type="checkbox"]'
+    }
+
+    // Escape name attribute for use in DOM selector
+    function escapeElementName (str) {
+      var result = str.replace('[', '\\[').replace(']', '\\]')
+      return result
+    }
+
+    // Adds ARIA attributes to control + associated content
+    function initToggledContent () {
+      var $control = $(this)
+      var $content = getToggledContent($control)
+
+      // Set aria-controls and defaults
+      if ($content.length) {
+        $control.attr('aria-controls', $content.attr('id'))
+        $control.attr('aria-expanded', 'false')
+        $content.attr('aria-hidden', 'true')
+      }
+    }
+
+    // Return toggled content for control
+    function getToggledContent ($control) {
+      var id = $control.attr('aria-controls')
+
+      // ARIA attributes aren't set before init
+      if (!id) {
+        id = $control.closest('[data-target]').data('target')
+      }
+
+      // Find show/hide content by id
+      return $('#' + id)
+    }
+
+    // Show toggled content for control
+    function showToggledContent ($control, $content) {
+      // Show content
+      if ($content.hasClass('js-hidden')) {
+        $content.removeClass('js-hidden')
+        $content.attr('aria-hidden', 'false')
+
+        // If the controlling input, update aria-expanded
+        if ($control.attr('aria-controls')) {
+          $control.attr('aria-expanded', 'true')
+        }
+      }
+    }
+
+    // Hide toggled content for control
+    function hideToggledContent ($control, $content) {
+      $content = $content || getToggledContent($control)
+
+      // Hide content
+      if (!$content.hasClass('js-hidden')) {
+        $content.addClass('js-hidden')
+        $content.attr('aria-hidden', 'true')
+
+        // If the controlling input, update aria-expanded
+        if ($control.attr('aria-controls')) {
+          $control.attr('aria-expanded', 'false')
+        }
+      }
+    }
+
+    // Handle radio show/hide
+    function handleRadioContent ($control, $content) {
+      // All radios in this group which control content
+      var selector = selectors.radio + '[name=' + escapeElementName($control.attr('name')) + '][aria-controls]'
+      var $form = $control.closest('form')
+      var $radios = $form.length ? $form.find(selector) : $(selector)
+
+      // Hide content for radios in group
+      $radios.each(function () {
+        hideToggledContent($(this))
+      })
+
+      // Select content for this control
+      if ($control.is('[aria-controls]')) {
+        showToggledContent($control, $content)
+      }
+    }
+
+    // Handle checkbox show/hide
+    function handleCheckboxContent ($control, $content) {
+      // Show checkbox content
+      if ($control.is(':checked')) {
+        showToggledContent($control, $content)
+      } else { // Hide checkbox content
+        hideToggledContent($control, $content)
+      }
+    }
+
+    // Set up event handlers etc
+    function init ($container, elementSelector, eventSelectors, handler) {
+      $container = $container || $(document.body)
+
+      // Handle control clicks
+      function deferred () {
+        var $control = $(this)
+        handler($control, getToggledContent($control))
+      }
+
+      // Prepare ARIA attributes
+      var $controls = $(elementSelector)
+      $controls.each(initToggledContent)
+
+      // Handle events
+      $.each(eventSelectors, function (idx, eventSelector) {
+        $container.on('click.' + selectors.namespace, eventSelector, deferred)
+      })
+
+      // Any already :checked on init?
+      if ($controls.is(':checked')) {
+        $controls.filter(':checked').each(deferred)
+      }
+    }
+
+    // Get event selectors for all radio groups
+    function getEventSelectorsForRadioGroups () {
+      var radioGroups = []
+
+      // Build an array of radio group selectors
+      return $(selectors.radio).map(function () {
+        var groupName = $(this).attr('name')
+
+        if ($.inArray(groupName, radioGroups) === -1) {
+          radioGroups.push(groupName)
+          return 'input[type="radio"][name="' + $(this).attr('name') + '"]'
+        }
+        return null
+      })
+    }
+
+    // Set up radio show/hide content for container
+    self.showHideRadioToggledContent = function ($container) {
+      init($container, selectors.radio, getEventSelectorsForRadioGroups(), handleRadioContent)
+    }
+
+    // Set up checkbox show/hide content for container
+    self.showHideCheckboxToggledContent = function ($container) {
+      init($container, selectors.checkbox, [selectors.checkbox], handleCheckboxContent)
+    }
+
+    // Remove event handlers
+    self.destroy = function ($container) {
+      $container = $container || $(document.body)
+      $container.off('.' + selectors.namespace)
+    }
+  }
+
+  ShowHideContent.prototype.init = function ($container) {
+    this.showHideRadioToggledContent($container)
+    this.showHideCheckboxToggledContent($container)
+  }
+
+  GOVUK.ShowHideContent = ShowHideContent
+  window.GOVUK = GOVUK
+}).call(window);

--- a/src/AppBundle/Resources/assets/scss/_common.scss
+++ b/src/AppBundle/Resources/assets/scss/_common.scss
@@ -1,5 +1,6 @@
 $path: '/images/';
 $govuk-assets-path: './';
+$govuk-images-path: '/images/';
 @import "node_modules/govuk-frontend/all";
 @import "govuk-elements";
 

--- a/src/AppBundle/Resources/assets/scss/_common.scss
+++ b/src/AppBundle/Resources/assets/scss/_common.scss
@@ -1,6 +1,7 @@
 $path: '/images/';
 $govuk-assets-path: './';
 $govuk-images-path: '/images/';
+$govuk-global-styles: true;
 @import "node_modules/govuk-frontend/all";
 @import "govuk-elements";
 

--- a/src/AppBundle/Resources/assets/scss/_shame.scss
+++ b/src/AppBundle/Resources/assets/scss/_shame.scss
@@ -14,12 +14,3 @@ b,
 strong {
     font-weight: 600;
 }
-
-// Use brand link colours for all links. We should be using `govuk-link`, but it's
-// hard to find all instances of this so we apply default styling.
-a {
-    &:link { color: $govuk-link-colour; }
-    &:visited { color: $govuk-link-visited-colour; }
-    &:hover { color: $govuk-link-hover-colour; }
-    &:active { color: $govuk-link-active-colour; }
-}

--- a/src/AppBundle/Resources/assets/scss/_shame.scss
+++ b/src/AppBundle/Resources/assets/scss/_shame.scss
@@ -1,14 +1,25 @@
 // Shame CSS
 // ==========================================================================
 
-// Undo the font-size overwrite in govuk-elements. It was to avoid an IE6/7 bug
-// but they're no longer supported and the overwrite made govuk-frontend unusable
-html { font-size: initial; }
-body { font-size: initial; }
+// Enable standard GDS typography on body elements. Most components automatically
+// apply the typography, but some (including custom ones) don't. This ensures the
+// font is consistently applied anyway.
+body {
+    @include govuk-typography-common;
+}
 
 // Undo the font-weight nullification in govuk-elements. It's no longer present in
 // the Design System, but so eager that it's still cascading through.
 b,
 strong {
     font-weight: 600;
+}
+
+// Use brand link colours for all links. We should be using `govuk-link`, but it's
+// hard to find all instances of this so we apply default styling.
+a {
+    &:link { color: $govuk-link-colour; }
+    &:visited { color: $govuk-link-visited-colour; }
+    &:hover { color: $govuk-link-hover-colour; }
+    &:active { color: $govuk-link-active-colour; }
 }

--- a/src/AppBundle/Resources/assets/scss/_shame.scss
+++ b/src/AppBundle/Resources/assets/scss/_shame.scss
@@ -14,3 +14,11 @@ b,
 strong {
     font-weight: 600;
 }
+
+// .hidden is used in a couple of places to manually hide something from the page
+// .js-hidden is used by some of our JavaScript modules to show/hide content
+.hidden,
+.js-enabled .js-hidden {
+    display: none;
+    visibility: hidden;
+}

--- a/src/AppBundle/Resources/assets/scss/application-print.scss
+++ b/src/AppBundle/Resources/assets/scss/application-print.scss
@@ -1,5 +1,0 @@
-#proposition-menu,
-.js-header-toggle,
-.navigation-back {
-    display: none;
-}

--- a/src/AppBundle/Resources/views/Layouts/application.html.twig
+++ b/src/AppBundle/Resources/views/Layouts/application.html.twig
@@ -8,8 +8,6 @@
 
 {% trans_default_domain "layout" %}
 
-{% block topOfPage %}{% endblock %}
-
 {% block head %}
     <meta name="format-detection" content="telephone=no">
 {% endblock %}

--- a/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
+++ b/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
@@ -1,16 +1,11 @@
-{% block topOfPage %}{% endblock %}
-
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="govuk-template">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
     <title>{% block htmlTitle %}Deputy report{% endblock %}</title>
 
     <link rel="shortcut icon" href="{{ asset('images/favicon.ico') }}" type="image/x-icon" />
-
-    <link href="{{ 'stylesheets/govuk-template.css'| assetUrl }}" rel="stylesheet" type="text/css"/>
-    <link href="{{ 'stylesheets/fonts.css'| assetUrl }}" media="all" rel="stylesheet" />
 
     <!-- Size for iPad and iPad mini (high resolution) -->
     <link rel="apple-touch-icon-precomposed" sizes="152x152" href="{{ asset('images/apple-touch-icon-152x152.png') }}">
@@ -37,7 +32,7 @@
     <script src="{{ '/javascripts/jquery.min.js' | assetUrl }}"></script>
   </head>
 
-  <body>
+  <body class="govuk-template__body">
       {% if ga is defined and ga is not null %}
         <script>
             (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
+++ b/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
@@ -25,8 +25,6 @@
 
     <link href="{{ 'stylesheets/application.css'| assetUrl }}"  rel="stylesheet" type="text/css">
 
-    <link href="{{ 'stylesheets/application-print.css'| assetUrl }}" media="print" rel="stylesheet" type="text/css" />
-
     {% block head %}{% endblock %}
 
     <script src="{{ '/javascripts/jquery.min.js' | assetUrl }}"></script>


### PR DESCRIPTION
## Purpose
We are in the process of moving to the [GOV.UK Design System](https://design-system.service.gov.uk/). This involves removing our dependencies on `govuk-elements-sass`, `govuk_frontend_toolkit` and `govuk_template_mustache`.

In this PR we remove the dependency on `govuk_template_mustache`.

Fixes [DDPB-2789](https://opgtransform.atlassian.net/browse/DDPB-2789)

## Approach
The core bit of work here is to remove `govuk_template_mustache` from our Gulp processes and its resultant CSS file from our HTML template. In doing so, we need to make a couple of replacements:

- Images and fonts are now pulled from `govuk-frontend` instead
- Some global overrides were added to `_shame.scss` because we still depend on them
- `show-hide-content.js` was extricated from `govuk_frontend_toolkit` into a separate JavaScript module

## Learning
This goes a long way to tidy up our asset delivery pipeline. This will make future changes easier, and should make the codebase easier to understand for developers.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes