### PR TITLE
Ddpb 2792 bump framework extra bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "twig/extensions": "^1.5.4",
         "symfony/swiftmailer-bundle": "^2.3.12",
         "symfony/monolog-bundle": "^2.8.2",
-        "sensio/framework-extra-bundle": "^3.0.29",
+        "sensio/framework-extra-bundle": "^5.0.0",
         "sensio/distribution-bundle": "^5.0.25",
         "incenteev/composer-parameter-handler": "^2.1.3",
         "guzzlehttp/guzzle": "^6.3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "af45130bfc6c0981853a062988b31821",
+    "content-hash": "6772209f23e8cbf6007163378f362292",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.104.0",
+            "version": "3.107.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "9feac27d183fa08f210f38c8cb6d449cf2411d29"
+                "reference": "99ec85834bbbeb9365c34a46b792c5421775f021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9feac27d183fa08f210f38c8cb6d449cf2411d29",
-                "reference": "9feac27d183fa08f210f38c8cb6d449cf2411d29",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/99ec85834bbbeb9365c34a46b792c5421775f021",
+                "reference": "99ec85834bbbeb9365c34a46b792c5421775f021",
                 "shasum": ""
             },
             "require": {
@@ -87,7 +87,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2019-07-02T18:21:12+00:00"
+            "time": "2019-07-22T18:31:27+00:00"
         },
         {
             "name": "behat/behat",
@@ -4566,40 +4566,43 @@
         },
         {
             "name": "sensio/framework-extra-bundle",
-            "version": "v3.0.29",
+            "version": "v5.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-                "reference": "bb907234df776b68922eb4b25bfa061683597b6a"
+                "reference": "585f4b3a1c54f24d1a8431c729fc8f5acca20c8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/bb907234df776b68922eb4b25bfa061683597b6a",
-                "reference": "bb907234df776b68922eb4b25bfa061683597b6a",
+                "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/585f4b3a1c54f24d1a8431c729fc8f5acca20c8a",
+                "reference": "585f4b3a1c54f24d1a8431c729fc8f5acca20c8a",
                 "shasum": ""
             },
             "require": {
-                "doctrine/common": "~2.2",
-                "symfony/dependency-injection": "~2.3|~3.0",
-                "symfony/framework-bundle": "~2.3|~3.0|~4.0"
+                "doctrine/annotations": "^1.0",
+                "doctrine/persistence": "^1.0",
+                "php": ">=7.1.3",
+                "symfony/config": "^3.4|^4.3",
+                "symfony/dependency-injection": "^3.4|^4.3",
+                "symfony/framework-bundle": "^3.4|^4.3",
+                "symfony/http-kernel": "^3.4|^4.3"
             },
             "require-dev": {
-                "doctrine/doctrine-bundle": "~1.5",
-                "doctrine/orm": "~2.4,>=2.4.5",
-                "symfony/asset": "~2.7|~3.0|~4.0",
-                "symfony/browser-kit": "~2.3|~3.0|~4.0",
-                "symfony/dom-crawler": "~2.3|~3.0|~4.0",
-                "symfony/expression-language": "~2.4|~3.0|~4.0",
-                "symfony/finder": "~2.3|~3.0|~4.0",
-                "symfony/phpunit-bridge": "~3.2|~4.0",
-                "symfony/psr-http-message-bridge": "^0.3|^1.0",
-                "symfony/security-bundle": "~2.4|~3.0|~4.0",
-                "symfony/templating": "~2.3|~3.0|~4.0",
-                "symfony/translation": "~2.3|~3.0|~4.0",
-                "symfony/twig-bundle": "~2.3|~3.0|~4.0",
-                "symfony/yaml": "~2.3|~3.0|~4.0",
-                "twig/twig": "~1.12|~2.0",
-                "zendframework/zend-diactoros": "^1.3"
+                "doctrine/doctrine-bundle": "^1.6",
+                "doctrine/orm": "^2.5",
+                "nyholm/psr7": "^1.1",
+                "symfony/browser-kit": "^3.4|^4.3",
+                "symfony/dom-crawler": "^3.4|^4.3",
+                "symfony/expression-language": "^3.4|^4.3",
+                "symfony/finder": "^3.4|^4.3",
+                "symfony/monolog-bridge": "^3.0|^4.0",
+                "symfony/monolog-bundle": "^3.2",
+                "symfony/phpunit-bridge": "^3.4.19|^4.1.8",
+                "symfony/psr-http-message-bridge": "^1.1",
+                "symfony/security-bundle": "^3.4|^4.3",
+                "symfony/twig-bundle": "^3.4|^4.3",
+                "symfony/yaml": "^3.4|^4.3",
+                "twig/twig": "~1.12|~2.0"
             },
             "suggest": {
                 "symfony/expression-language": "",
@@ -4609,7 +4612,7 @@
             "type": "symfony-bundle",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "5.4.x-dev"
                 }
             },
             "autoload": {
@@ -4632,11 +4635,11 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2017-12-14T19:03:23+00:00"
+            "time": "2019-07-08T08:31:25+00:00"
         },
         {
             "name": "sensiolabs/security-checker",
-            "version": "v6.0.1",
+            "version": "v6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/security-checker.git",

--- a/docs/TECH_DEBT.md
+++ b/docs/TECH_DEBT.md
@@ -9,3 +9,11 @@ A log of technical debt we're aware of and have accepted. These aren't "problems
 - We define status label translations in `common.en.yml` (twice), `ndr-overview.en.yml` (twice) and `report-overview.en.yml` (twice). Using one, clear definition would make it easier to make changes in the future
 - We should use `bin/phpunit` when running tests (instead of `vendor/phpunit/phpunit/phpunit`)
 - `behat-debugger.php` is a poor way of dealing with test failures: it requires explicit setup in our NGINX configuration files and doesn't always collect useful information (e.g. just showing "Application error" when something crashes)
+- We have several duplicated template files (albeit the main content differs) that we could consider making reusable. `start.html.twig` and `add_another.html.twig` are good examples to start with
+- Since version 5.2 of `sensio/framework-extra-bundle`, the `Route` and `Method` annotations have been deprecated and moved into the Symfony routing component. We should deprecate the bundle from using it with:
+```$xslt
+sensio_framework_extra:
+    router:
+        annotations: false
+```
+and replace the annotations `Sensio\Bundle\FrameworkExtraBundle\Configuration\Route` and `Sensio\Bundle\FrameworkExtraBundle\Configuration\Method` with `Symfony\Component\Routing\Annotation\Route`

--- a/src/AppBundle/Controller/Admin/AdController.php
+++ b/src/AppBundle/Controller/Admin/AdController.php
@@ -19,7 +19,7 @@ class AdController extends AbstractController
     /**
      * @Route("/", name="ad_homepage")
      * @Security("has_role('ROLE_AD')")
-     * @Template
+     * @Template("AppBundle:Admin/Ad:index.html.twig")
      */
     public function indexAction(Request $request)
     {
@@ -76,7 +76,7 @@ class AdController extends AbstractController
      * @Route("/view-user", name="ad_view_user")
      * @Security("has_role('ROLE_AD')")
      * @Method({"GET", "POST"})
-     * @Template
+     * @Template("AppBundle:Admin/Ad:viewUser.html.twig")
      *
      * @param Request $request
      */

--- a/src/AppBundle/Controller/Admin/AjaxController.php
+++ b/src/AppBundle/Controller/Admin/AjaxController.php
@@ -6,7 +6,6 @@ use AppBundle\Controller\AbstractController;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -19,7 +18,6 @@ class AjaxController extends AbstractController
     /**
      * @Route("/casrec-truncate", name="casrec_truncate_ajax")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
      */
     public function truncateUsersAjaxAction(Request $request)
     {
@@ -37,7 +35,6 @@ class AjaxController extends AbstractController
     /**
      * @Route("/casrec-add", name="casrec_add_ajax")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
      */
     public function uploadUsersAjaxAction(Request $request)
     {
@@ -63,7 +60,6 @@ class AjaxController extends AbstractController
      * @Route("/org-chunk-add", name="org_add_ajax")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Method({"POST"})
-     * @Template
      */
     public function uploadPaAjaxAction(Request $request)
     {

--- a/src/AppBundle/Controller/Admin/Client/ClientController.php
+++ b/src/AppBundle/Controller/Admin/Client/ClientController.php
@@ -20,7 +20,7 @@ class ClientController extends AbstractController
      * @param Request $request
      * @param $id
      *
-     * @Template()
+     * @Template("AppBundle:Admin/Client/Client:details.html.twig")
      *
      * @return array
      */

--- a/src/AppBundle/Controller/Admin/Client/ReportController.php
+++ b/src/AppBundle/Controller/Admin/Client/ReportController.php
@@ -85,7 +85,7 @@ class ReportController extends AbstractController
      * @param Request $request
      * @param $id
      *
-     * @Template()
+     * @Template("AppBundle:Admin/Client/Report:manage.html.twig")
      *
      * @return array
      */
@@ -219,7 +219,7 @@ class ReportController extends AbstractController
      * @param Request $request
      * @param $id
      *
-     * @Template()
+     * @Template("AppBundle:Admin/Client/Report:checklist.html.twig")
      *
      * @return array
      */

--- a/src/AppBundle/Controller/Admin/Client/SearchController.php
+++ b/src/AppBundle/Controller/Admin/Client/SearchController.php
@@ -19,7 +19,7 @@ class SearchController extends AbstractController
      * @Route("/search", name="admin_client_search")
      * //TODO define Security group (AD to remove?)
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD') or has_role('ROLE_CASE_MANAGER')")
-     * @Template
+     * @Template("AppBundle:Admin/Client/Search:search.html.twig")
      */
     public function searchAction(Request $request)
     {

--- a/src/AppBundle/Controller/Admin/IndexController.php
+++ b/src/AppBundle/Controller/Admin/IndexController.php
@@ -420,7 +420,7 @@ class IndexController extends AbstractController
     /**
      * @Route("/org-csv-upload", name="admin_org_upload")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template("AppBundle:Admin/Index:upgradeOrgUsers.html.twig")
+     * @Template("AppBundle:Admin/Index:uploadOrgUsers.html.twig")
      */
     public function uploadOrgUsersAction(Request $request)
     {

--- a/src/AppBundle/Controller/Admin/IndexController.php
+++ b/src/AppBundle/Controller/Admin/IndexController.php
@@ -26,7 +26,7 @@ class IndexController extends AbstractController
     /**
      * @Route("/", name="admin_homepage")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
+     * @Template("AppBundle:Admin/Index:index.html.twig")
      */
     public function indexAction(Request $request)
     {
@@ -58,7 +58,7 @@ class IndexController extends AbstractController
     /**
      * @Route("/user-add", name="admin_add_user")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
+     * @Template("AppBundle:Admin/Index:addUser.html.twig")
      */
     public function addUserAction(Request $request)
     {
@@ -113,7 +113,7 @@ class IndexController extends AbstractController
      * @Route("/edit-user", name="admin_editUser")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Method({"GET", "POST"})
-     * @Template
+     * @Template("AppBundle:Admin/Index:editUser.html.twig")
      *
      * @param Request $request
      */
@@ -125,13 +125,13 @@ class IndexController extends AbstractController
             /* @var $user EntityDir\User */
             $user = $this->getRestClient()->get("v2/deputy/{$filter}", 'User');
         } catch (\Throwable $e) {
-            return $this->render('AppBundle:Admin:error.html.twig', [
+            return $this->render('AppBundle:Admin/Index:error.html.twig', [
                 'error' => 'User not found',
             ]);
         }
 
         if ($user->getRoleName() == EntityDir\User::ROLE_ADMIN && !$this->isGranted(EntityDir\User::ROLE_ADMIN)) {
-            return $this->render('AppBundle:Admin:error.html.twig', [
+            return $this->render('AppBundle:Admin/Index:error.html.twig', [
                 'error' => 'Non-admin cannot edit admin users',
             ]);
         }
@@ -239,7 +239,7 @@ class IndexController extends AbstractController
      * @Route("/delete-confirm/{id}", name="admin_delete_confirm")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Method({"GET"})
-     * @Template()
+     * @Template("AppBundle:Admin/Index:deleteConfirm.html.twig")
      *
      * @param int $id
      *
@@ -264,7 +264,6 @@ class IndexController extends AbstractController
      * @Route("/delete/{id}", name="admin_delete")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
      * @Method({"GET"})
-     * @Template()
      *
      * @param int $id
      *
@@ -282,7 +281,7 @@ class IndexController extends AbstractController
     /**
      * @Route("/casrec-upload", name="casrec_upload")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
+     * @Template("AppBundle:Admin/Index:uploadUsers.html.twig")
      */
     public function uploadUsersAction(Request $request)
     {
@@ -370,7 +369,7 @@ class IndexController extends AbstractController
     /**
      * @Route("/casrec-mld-upgrade", name="casrec_mld_upgrade")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
+     * @Template("AppBundle:Admin/Index:upgradeMld.html.twig")
      */
     public function upgradeMldAction(Request $request)
     {
@@ -421,7 +420,7 @@ class IndexController extends AbstractController
     /**
      * @Route("/org-csv-upload", name="admin_org_upload")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
+     * @Template("AppBundle:Admin/Index:upgradeOrgUsers.html.twig")
      */
     public function uploadOrgUsersAction(Request $request)
     {

--- a/src/AppBundle/Controller/Admin/ReportSubmissionController.php
+++ b/src/AppBundle/Controller/Admin/ReportSubmissionController.php
@@ -23,7 +23,7 @@ class ReportSubmissionController extends AbstractController
     /**
      * @Route("/documents/list", name="admin_documents")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
+     * @Template("AppBundle:Admin/ReportSubmission:index.html.twig")
      */
     public function indexAction(Request $request)
     {

--- a/src/AppBundle/Controller/Admin/SettingController.php
+++ b/src/AppBundle/Controller/Admin/SettingController.php
@@ -17,7 +17,7 @@ class SettingController extends AbstractController
     /**
      * @Route("/service-notification", name="admin_setting_service_notifications")
      * @Security("has_role('ROLE_ADMIN')")
-     * @Template
+     * @Template("AppBundle:Admin/Setting:serviceNotification.html.twig")
      */
     public function serviceNotificationAction(Request $request)
     {

--- a/src/AppBundle/Controller/Admin/StatsController.php
+++ b/src/AppBundle/Controller/Admin/StatsController.php
@@ -20,7 +20,7 @@ class StatsController extends AbstractController
     /**
      * @Route("", name="admin_stats")
      * @Security("has_role('ROLE_ADMIN') or has_role('ROLE_AD')")
-     * @Template
+     * @Template("AppBundle:Admin/Stats:stats.html.twig")
      * @param Request $request
      * @return array|Response
      */

--- a/src/AppBundle/Controller/BehatController.php
+++ b/src/AppBundle/Controller/BehatController.php
@@ -58,7 +58,7 @@ class BehatController extends AbstractController
     /**
      * @Route("/behat/emails")
      * @Method({"GET"})
-     * @Template
+     * @Template("AppBundle:Behat:emails.html.twig")
      */
     public function emailsAction(Request $request)
     {
@@ -80,7 +80,6 @@ class BehatController extends AbstractController
      * Login is required
      *
      * @Route("/email-viewer/{action}/{type}", name="email-viewer", defaults={"type"="html"})
-     * @Template()
      */
     public function emailViewerAction($action, $type = 'html')
     {

--- a/src/AppBundle/Controller/ClientController.php
+++ b/src/AppBundle/Controller/ClientController.php
@@ -13,7 +13,7 @@ class ClientController extends AbstractController
 {
     /**
      * @Route("/deputyship-details/your-client", name="client_show")
-     * @Template()
+     * @Template("AppBundle:Client:show.html.twig")
      */
     public function showAction(Request $request)
     {
@@ -33,7 +33,7 @@ class ClientController extends AbstractController
 
     /**
      * @Route("/deputyship-details/your-client/edit", name="client_edit")
-     * @Template()
+     * @Template("AppBundle:Client:edit.html.twig")
      */
     public function editAction(Request $request)
     {
@@ -77,7 +77,7 @@ class ClientController extends AbstractController
 
     /**
      * @Route("/client/add", name="client_add")
-     * @Template()
+     * @Template("AppBundle:Client:add.html.twig")
      */
     public function addAction(Request $request)
     {

--- a/src/AppBundle/Controller/CoDeputyController.php
+++ b/src/AppBundle/Controller/CoDeputyController.php
@@ -14,7 +14,7 @@ class CoDeputyController extends AbstractController
 {
     /**
      * @Route("/codeputy/verification", name="codep_verification")
-     * @Template()
+     * @Template("AppBundle:CoDeputy:verification.html.twig")
      */
     public function verificationAction(Request $request)
     {
@@ -96,7 +96,7 @@ class CoDeputyController extends AbstractController
 
     /**
      * @Route("/codeputy/{clientId}/add", name="add_co_deputy")
-     * @Template()
+     * @Template("AppBundle:CoDeputy:add.html.twig")
      */
     public function addAction(Request $request)
     {
@@ -151,7 +151,7 @@ class CoDeputyController extends AbstractController
 
     /**
      * @Route("/codeputy/re-invite/{email}", name="codep_resend_activation")
-     * @Template()
+     * @Template("AppBundle:CoDeputy:resendActivation.html.twig")
      **/
     public function resendActivationAction(Request $request, $email)
     {

--- a/src/AppBundle/Controller/IndexController.php
+++ b/src/AppBundle/Controller/IndexController.php
@@ -31,7 +31,7 @@ class IndexController extends AbstractController
 
     /**
      * @Route("login", name="login")
-     * @Template()
+     * @Template("AppBundle:Index:login.html.twig")
      */
     public function loginAction(Request $request)
     {
@@ -207,7 +207,6 @@ class IndexController extends AbstractController
 
     /**
      * @Route("/logout", name="logout")
-     * @Template
      */
     public function logoutAction(Request $request)
     {

--- a/src/AppBundle/Controller/ManageController.php
+++ b/src/AppBundle/Controller/ManageController.php
@@ -15,7 +15,6 @@ class ManageController extends AbstractController
     /**
      * @Route("/availability")
      * @Method({"GET"})
-     * @Template
      */
     public function availabilityAction()
     {

--- a/src/AppBundle/Controller/ManageController.php
+++ b/src/AppBundle/Controller/ManageController.php
@@ -53,7 +53,7 @@ class ManageController extends AbstractController
     /**
      * @Route("/elb", name="manage-elb")
      * @Method({"GET"})
-     * @Template()
+     * @Template("AppBundle:Manage:elb.html.twig")
      */
     public function elbAction()
     {

--- a/src/AppBundle/Controller/Ndr/ActionController.php
+++ b/src/AppBundle/Controller/Ndr/ActionController.php
@@ -20,7 +20,7 @@ class ActionController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/actions", name="ndr_actions")
-     * @Template()
+     * @Template("AppBundle:Ndr/Action:start.html.twig")
      */
     public function startAction(Request $request, $ndrId)
     {
@@ -36,7 +36,7 @@ class ActionController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/actions/step/{step}", name="ndr_actions_step")
-     * @Template()
+     * @Template("AppBundle:Ndr/Action:step.html.twig")
      */
     public function stepAction(Request $request, $ndrId, $step)
     {
@@ -82,7 +82,7 @@ class ActionController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/actions/summary", name="ndr_actions_summary")
-     * @Template()
+     * @Template("AppBundle:Ndr/Action:summary.html.twig")
      */
     public function summaryAction(Request $request, $ndrId)
     {

--- a/src/AppBundle/Controller/Ndr/AssetController.php
+++ b/src/AppBundle/Controller/Ndr/AssetController.php
@@ -17,7 +17,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/assets", name="ndr_assets")
-     * @Template()
+     * @Template("AppBundle:Ndr/Asset:start.html.twig")
      *
      * @param int $ndrId
      *
@@ -37,7 +37,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/assets/exist", name="ndr_assets_exist")
-     * @Template()
+     * @Template("AppBundle:Ndr/Asset:exist.html.twig")
      */
     public function existAction(Request $request, $ndrId)
     {
@@ -77,7 +77,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/assets/step-type", name="ndr_assets_type")
-     * @Template()
+     * @Template("AppBundle:Ndr/Asset:type.html.twig")
      */
     public function typeAction(Request $request, $ndrId)
     {
@@ -171,7 +171,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/assets/add_another", name="ndr_assets_add_another")
-     * @Template()
+     * @Template("AppBundle:Ndr/Asset:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $ndrId)
     {
@@ -318,7 +318,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/assets/summary", name="ndr_assets_summary")
-     * @Template()
+     * @Template("AppBundle:Ndr/Asset:summary.html.twig")
      *
      * @param int $ndrId
      *

--- a/src/AppBundle/Controller/Ndr/BankAccountController.php
+++ b/src/AppBundle/Controller/Ndr/BankAccountController.php
@@ -17,7 +17,7 @@ class BankAccountController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/bank-accounts", name="ndr_bank_accounts")
-     * @Template()
+     * @Template("AppBundle:Ndr/BankAccount:start.html.twig")
      */
     public function startAction(Request $request, $ndrId)
     {
@@ -33,7 +33,7 @@ class BankAccountController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/bank-account/step{step}/{accountId}", name="ndr_bank_accounts_step", requirements={"step":"\d+"})
-     * @Template()
+     * @Template("AppBundle:Ndr/BankAccount:step.html.twig")
      */
     public function stepAction(Request $request, $ndrId, $step, $accountId = null)
     {
@@ -154,7 +154,7 @@ class BankAccountController extends AbstractController
      * @Route("/ndr/{ndrId}/bank-accounts/summary", name="ndr_bank_accounts_summary")
      *
      * @param int $ndrId
-     * @Template()
+     * @Template("AppBundle:Ndr/BankAccount:summary.html.twig")
      *
      * @return array
      */

--- a/src/AppBundle/Controller/Ndr/DebtController.php
+++ b/src/AppBundle/Controller/Ndr/DebtController.php
@@ -16,7 +16,7 @@ class DebtController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/debts", name="ndr_debts")
-     * @Template()
+     * @Template("AppBundle:Ndr/Debt:start.html.twig")
      */
     public function startAction(Request $request, $ndrId)
     {
@@ -32,7 +32,7 @@ class DebtController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/debts/exist", name="ndr_debts_exist")
-     * @Template()
+     * @Template("AppBundle:Ndr/Debt:exist.html.twig")
      */
     public function existAction(Request $request, $ndrId)
     {
@@ -67,7 +67,7 @@ class DebtController extends AbstractController
      * List debts.
      *
      * @Route("/ndr/{ndrId}/debts/edit", name="ndr_debts_edit")
-     * @Template()
+     * @Template("AppBundle:Ndr/Debt:edit.html.twig")
      */
     public function editAction(Request $request, $ndrId)
     {
@@ -103,7 +103,7 @@ class DebtController extends AbstractController
      * How debts are managed question.
      *
      * @Route("/ndr/{ndrId}/debts/management", name="ndr_debts_management")
-     * @Template()
+     * @Template("AppBundle:Ndr/Debt:management.html.twig")
      */
     public function managementAction(Request $request, $ndrId)
     {
@@ -141,7 +141,7 @@ class DebtController extends AbstractController
      * List debts.
      *
      * @Route("/ndr/{ndrId}/debts/summary", name="ndr_debts_summary")
-     * @Template()
+     * @Template("AppBundle:Ndr/Debt:summary.html.twig")
      */
     public function summaryAction(Request $request, $ndrId)
     {

--- a/src/AppBundle/Controller/Ndr/DeputyExpenseController.php
+++ b/src/AppBundle/Controller/Ndr/DeputyExpenseController.php
@@ -18,7 +18,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/deputy-expenses", name="ndr_deputy_expenses")
-     * @Template()
+     * @Template("AppBundle:Ndr/DeputyExpense:start.html.twig")
      *
      * @param int $ndrId
      *
@@ -39,7 +39,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/deputy-expenses/exist", name="ndr_deputy_expenses_exist")
-     * @Template()
+     * @Template("AppBundle:Ndr/DeputyExpense:exist.html.twig")
      */
     public function existAction(Request $request, $ndrId)
     {
@@ -74,7 +74,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/deputy-expenses/add", name="ndr_deputy_expenses_add")
-     * @Template()
+     * @Template("AppBundle:Ndr/DeputyExpense:add.html.twig")
      */
     public function addAction(Request $request, $ndrId)
     {
@@ -106,7 +106,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/deputy-expenses/add_another", name="ndr_deputy_expenses_add_another")
-     * @Template()
+     * @Template("AppBundle:Ndr/DeputyExpense:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $ndrId)
     {
@@ -132,7 +132,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/deputy-expenses/edit/{expenseId}", name="ndr_deputy_expenses_edit")
-     * @Template()
+     * @Template("AppBundle:Ndr/DeputyExpense:edit.html.twig")
      */
     public function editAction(Request $request, $ndrId, $expenseId)
     {
@@ -160,7 +160,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/deputy-expenses/summary", name="ndr_deputy_expenses_summary")
-     * @Template()
+     * @Template("AppBundle:Ndr/DeputyExpense:summary.html.twig")
      *
      * @param int $ndrId
      *

--- a/src/AppBundle/Controller/Ndr/IncomeBenefitController.php
+++ b/src/AppBundle/Controller/Ndr/IncomeBenefitController.php
@@ -22,7 +22,7 @@ class IncomeBenefitController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/income-benefits", name="ndr_income_benefits")
-     * @Template()
+     * @Template("AppBundle:Ndr/IncomeBenefit:start.html.twig")
      */
     public function startAction(Request $request, $ndrId)
     {
@@ -38,7 +38,7 @@ class IncomeBenefitController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/income-benefits/step/{step}", name="ndr_income_benefits_step")
-     * @Template()
+     * @Template("AppBundle:Ndr/IncomeBenefit:step.html.twig")
      */
     public function stepAction(Request $request, $ndrId, $step)
     {
@@ -96,7 +96,7 @@ class IncomeBenefitController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/income-benefits/summary", name="ndr_income_benefits_summary")
-     * @Template()
+     * @Template("AppBundle:Ndr/IncomeBenefit:summary.html.twig")
      */
     public function summaryAction(Request $request, $ndrId)
     {

--- a/src/AppBundle/Controller/Ndr/NdrController.php
+++ b/src/AppBundle/Controller/Ndr/NdrController.php
@@ -42,7 +42,7 @@ class NdrController extends AbstractController
      * //TODO move view into Ndr directory when branches are integrated.
      *
      * @Route("/ndr", name="ndr_index")
-     * @Template()
+     * @Template("AppBundle:Ndr/Ndr:index.html.twig")
      */
     public function indexAction()
     {
@@ -68,7 +68,7 @@ class NdrController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/overview", name="ndr_overview")
-     * @Template()
+     * @Template("AppBundle:Ndr/Ndr:overview.html.twig")
      */
     public function overviewAction($ndrId)
     {
@@ -96,7 +96,7 @@ class NdrController extends AbstractController
      * Used for active and archived NDRs.
      *
      * @Route("/ndr/{ndrId}/review", name="ndr_review")
-     * @Template()
+     * @Template("AppBundle:Ndr/Ndr:review.html.twig")
      */
     public function reviewAction($ndrId)
     {
@@ -152,7 +152,7 @@ class NdrController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/declaration", name="ndr_declaration")
-     * @Template()
+     * @Template("AppBundle:Ndr/Ndr:declaration.html.twig")
      */
     public function declarationAction(Request $request, $ndrId)
     {
@@ -215,7 +215,7 @@ class NdrController extends AbstractController
      * Page displaying the report has been submitted.
      *
      * @Route("/ndr/{ndrId}/submitted", name="ndr_submit_confirmation")
-     * @Template()
+     * @Template("AppBundle:Ndr/Ndr:submitConfirmation.html.twig")
      */
     public function submitConfirmationAction(Request $request, $ndrId)
     {

--- a/src/AppBundle/Controller/Ndr/OtherInfoController.php
+++ b/src/AppBundle/Controller/Ndr/OtherInfoController.php
@@ -18,7 +18,7 @@ class OtherInfoController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/any-other-info", name="ndr_other_info")
-     * @Template()
+     * @Template("AppBundle:Ndr/OtherInfo:start.html.twig")
      */
     public function startAction(Request $request, $ndrId)
     {
@@ -34,7 +34,7 @@ class OtherInfoController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/any-other-info/step/{step}", name="ndr_other_info_step")
-     * @Template()
+     * @Template("AppBundle:Ndr/OtherInfo:step.html.twig")
      */
     public function stepAction(Request $request, $ndrId, $step)
     {
@@ -79,7 +79,7 @@ class OtherInfoController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/any-other-info/summary", name="ndr_other_info_summary")
-     * @Template()
+     * @Template("AppBundle:Ndr/OtherInfo:summary.html.twig")
      */
     public function summaryAction(Request $request, $ndrId)
     {

--- a/src/AppBundle/Controller/Ndr/VisitsCareController.php
+++ b/src/AppBundle/Controller/Ndr/VisitsCareController.php
@@ -18,7 +18,7 @@ class VisitsCareController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/visits-care", name="ndr_visits_care")
-     * @Template()
+     * @Template("AppBundle:Ndr/VisitsCare:start.html.twig")
      */
     public function startAction(Request $request, $ndrId)
     {
@@ -34,7 +34,7 @@ class VisitsCareController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/visits-care/step/{step}", name="ndr_visits_care_step")
-     * @Template()
+     * @Template("AppBundle:Ndr/VisitsCare:step.html.twig")
      */
     public function stepAction(Request $request, $ndrId, $step)
     {
@@ -93,7 +93,7 @@ class VisitsCareController extends AbstractController
 
     /**
      * @Route("/ndr/{ndrId}/visits-care/summary", name="ndr_visits_care_summary")
-     * @Template()
+     * @Template("AppBundle:Ndr/VisitsCare:summary.html.twig")
      */
     public function summaryAction(Request $request, $ndrId)
     {

--- a/src/AppBundle/Controller/Org/IndexController.php
+++ b/src/AppBundle/Controller/Org/IndexController.php
@@ -17,7 +17,7 @@ class IndexController extends AbstractController
 {
     /**
      * @Route("/", name="org_dashboard")
-     * @Template
+     * @Template("AppBundle:Org/Index:dashboard.html.twig")
      */
     public function dashboardAction(Request $request)
     {
@@ -56,7 +56,7 @@ class IndexController extends AbstractController
      * so it's retrieved with the report with a single API call
      *
      * @Route("/client/{clientId}/edit", name="org_client_edit")
-     * @Template
+     * @Template("AppBundle:Org/Index:clientEdit.html.twig")
      */
     public function clientEditAction(Request $request, $clientId)
     {
@@ -92,7 +92,7 @@ class IndexController extends AbstractController
      * Client archive page
      *
      * @Route("/client/{clientId}/archive", name="org_client_archive")
-     * @Template
+     * @Template("AppBundle:Org/Index:clientArchive.html.twig")
      */
     public function clientArchiveAction(Request $request, $clientId)
     {

--- a/src/AppBundle/Controller/Org/NoteController.php
+++ b/src/AppBundle/Controller/Org/NoteController.php
@@ -123,7 +123,6 @@ class NoteController extends AbstractController
      * Removes a note, adds a flash message and redirects to page
      *
      * @Route("{noteId}/delete/confirm", name="delete_note_confirm")
-     * @Template()
      */
     public function deleteConfirmedAction(Request $request, $noteId)
     {

--- a/src/AppBundle/Controller/Org/TeamController.php
+++ b/src/AppBundle/Controller/Org/TeamController.php
@@ -19,7 +19,7 @@ class TeamController extends AbstractController
 {
     /**
      * @Route("", name="org_team")
-     * @Template
+     * @Template("AppBundle:Org/Team:list.html.twig")
      */
     public function listAction(Request $request)
     {
@@ -32,7 +32,7 @@ class TeamController extends AbstractController
 
     /**
      * @Route("/add", name="add_team_member")
-     * @Template()
+     * @Template("AppBundle:Org/Team:add.html.twig")
      */
     public function addAction(Request $request)
     {
@@ -118,7 +118,7 @@ class TeamController extends AbstractController
 
     /**
      * @Route("/edit/{id}", name="edit_team_member")
-     * @Template()
+     * @Template("AppBundle:Org/Team:edit.html.twig")
      */
     public function editAction(Request $request, $id)
     {
@@ -216,7 +216,7 @@ class TeamController extends AbstractController
      * Confirm delete user form
      *
      * @Route("/delete-user/{id}", name="delete_team_member")
-     * @Template()
+     * @Template("AppBundle:Org/Team:deleteConfirm.html.twig")
      */
     public function deleteConfirmAction(Request $request, $id, $confirmed = false)
     {
@@ -232,7 +232,6 @@ class TeamController extends AbstractController
      * Removes a user, adds a flash message and redirects to page
      *
      * @Route("/delete-user/{id}/confirm", name="delete_team_member_confirm")
-     * @Template()
      */
     public function deleteConfirmedAction(Request $request, $id)
     {

--- a/src/AppBundle/Controller/Report/ActionController.php
+++ b/src/AppBundle/Controller/Report/ActionController.php
@@ -20,7 +20,7 @@ class ActionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/actions", name="actions")
-     * @Template()
+     * @Template("AppBundle:Report/Action:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -36,7 +36,7 @@ class ActionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/actions/step/{step}", name="actions_step")
-     * @Template()
+     * @Template("AppBundle:Report/Action:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step)
     {
@@ -88,7 +88,7 @@ class ActionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/actions/summary", name="actions_summary")
-     * @Template()
+     * @Template("AppBundle:Report/Action:summary.html.twig")
      */
     public function summaryAction(Request $request, $reportId)
     {

--- a/src/AppBundle/Controller/Report/AssetController.php
+++ b/src/AppBundle/Controller/Report/AssetController.php
@@ -22,7 +22,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/assets", name="assets")
-     * @Template()
+     * @Template("AppBundle:Report/Asset:start.html.twig")
      *
      * @param int $reportId
      *
@@ -42,7 +42,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/assets/exist", name="assets_exist")
-     * @Template()
+     * @Template("AppBundle:Report/Asset:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -82,7 +82,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/assets/step-type", name="assets_type")
-     * @Template()
+     * @Template("AppBundle:Report/Asset:type.html.twig")
      */
     public function typeAction(Request $request, $reportId)
     {
@@ -176,7 +176,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/assets/add_another", name="assets_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/Asset:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -325,7 +325,7 @@ class AssetController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/assets/summary", name="assets_summary")
-     * @Template()
+     * @Template("AppBundle:Report/Asset:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/BalanceController.php
+++ b/src/AppBundle/Controller/Report/BalanceController.php
@@ -35,7 +35,7 @@ class BalanceController extends AbstractController
      * @Route("/report/{reportId}/balance", name="balance")
      *
      * @param int $reportId
-     * @Template()
+     * @Template("AppBundle:Report/Balance:balance.html.twig")
      *
      * @return array
      */

--- a/src/AppBundle/Controller/Report/BankAccountController.php
+++ b/src/AppBundle/Controller/Report/BankAccountController.php
@@ -19,7 +19,7 @@ class BankAccountController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/bank-accounts", name="bank_accounts")
-     * @Template()
+     * @Template("AppBundle:Report/BankAccount:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -35,7 +35,7 @@ class BankAccountController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/bank-account/step{step}/{accountId}", name="bank_accounts_step", requirements={"step":"\d+"})
-     * @Template()
+     * @Template("AppBundle:Report/BankAccount:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step, $accountId = null)
     {
@@ -172,7 +172,7 @@ class BankAccountController extends AbstractController
      * @Route("/report/{reportId}/bank-accounts/summary", name="bank_accounts_summary")
      *
      * @param int $reportId
-     * @Template()
+     * @Template("AppBundle:Report/BankAccount:summary.html.twig")
      *
      * @return array
      */
@@ -194,7 +194,7 @@ class BankAccountController extends AbstractController
      * @param int $reportId
      * @param int $accountId
      *
-     * @Template()
+     * @Template("AppBundle:Report/BankAccount:deleteConfirm.html.twig")
      */
     public function deleteConfirmAction(Request $request, $reportId, $accountId)
     {

--- a/src/AppBundle/Controller/Report/ContactController.php
+++ b/src/AppBundle/Controller/Report/ContactController.php
@@ -20,7 +20,7 @@ class ContactController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/contacts", name="contacts")
-     * @Template()
+     * @Template("AppBundle:Report/Contact:start.html.twig")
      *
      * @param int $reportId
      *
@@ -41,7 +41,7 @@ class ContactController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/contacts/exist", name="contacts_exist")
-     * @Template()
+     * @Template("AppBundle:Report/Contact:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -76,7 +76,7 @@ class ContactController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/contacts/add", name="contacts_add")
-     * @Template()
+     * @Template("AppBundle:Report/Contact:add.html.twig")
      */
     public function addAction(Request $request, $reportId)
     {
@@ -108,7 +108,7 @@ class ContactController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/contacts/add_another", name="contacts_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/Contact:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -134,7 +134,7 @@ class ContactController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/contacts/edit/{contactId}", name="contacts_edit")
-     * @Template()
+     * @Template("AppBundle:Report/Contact:edit.html.twig")
      */
     public function editAction(Request $request, $reportId, $contactId)
     {
@@ -164,7 +164,7 @@ class ContactController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/contacts/summary", name="contacts_summary")
-     * @Template()
+     * @Template("AppBundle:Report/Contact:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/DebtController.php
+++ b/src/AppBundle/Controller/Report/DebtController.php
@@ -20,7 +20,7 @@ class DebtController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/debts", name="debts")
-     * @Template()
+     * @Template("AppBundle:Report/Debt:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -36,7 +36,7 @@ class DebtController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/debts/exist", name="debts_exist")
-     * @Template()
+     * @Template("AppBundle:Report/Debt:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -71,7 +71,7 @@ class DebtController extends AbstractController
      * List debts.
      *
      * @Route("/report/{reportId}/debts/edit", name="debts_edit")
-     * @Template()
+     * @Template("AppBundle:Report/Debt:edit.html.twig")
      */
     public function editAction(Request $request, $reportId)
     {
@@ -110,7 +110,7 @@ class DebtController extends AbstractController
      * How debts are managed question.
      *
      * @Route("/report/{reportId}/debts/management", name="debts_management")
-     * @Template()
+     * @Template("AppBundle:Report/Debt:management.html.twig")
      */
     public function managementAction(Request $request, $reportId)
     {
@@ -147,7 +147,7 @@ class DebtController extends AbstractController
      * List debts.
      *
      * @Route("/report/{reportId}/debts/summary", name="debts_summary")
-     * @Template()
+     * @Template("AppBundle:Report/Debt:summary.html.twig")
      */
     public function summaryAction(Request $request, $reportId)
     {

--- a/src/AppBundle/Controller/Report/DecisionController.php
+++ b/src/AppBundle/Controller/Report/DecisionController.php
@@ -21,7 +21,7 @@ class DecisionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/decisions", name="decisions")
-     * @Template()
+     * @Template("AppBundle:Report/Decision:start.html.twig")
      *
      * @param int $reportId
      *
@@ -79,7 +79,7 @@ class DecisionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/decisions/mental-assessment", name="decisions_mental_assessment")
-     * @Template()
+     * @Template("AppBundle:Report/Decision:mentalAssessment.html.twig")
      */
     public function mentalAssessmentAction(Request $request, $reportId)
     {
@@ -117,7 +117,7 @@ class DecisionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/decisions/exist", name="decisions_exist")
-     * @Template()
+     * @Template("AppBundle:Report/Decision:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -152,7 +152,7 @@ class DecisionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/decisions/add", name="decisions_add")
-     * @Template()
+     * @Template("AppBundle:Report/Decision:add.html.twig")
      */
     public function addAction(Request $request, $reportId)
     {
@@ -184,7 +184,7 @@ class DecisionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/decisions/add_another", name="decisions_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/Decision:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -210,7 +210,7 @@ class DecisionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/decisions/edit/{decisionId}", name="decisions_edit")
-     * @Template()
+     * @Template("AppBundle:Report/Decision:edit.html.twig")
      */
     public function editAction(Request $request, $reportId, $decisionId)
     {
@@ -241,7 +241,7 @@ class DecisionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/decisions/summary", name="decisions_summary")
-     * @Template()
+     * @Template("AppBundle:Report/Decision:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/DecisionController.php
+++ b/src/AppBundle/Controller/Report/DecisionController.php
@@ -42,7 +42,7 @@ class DecisionController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/decisions/mental-capacity", name="decisions_mental_capacity")
-     * @Template()
+     * @Template("AppBundle:Report/Decision:mentalCapacity.html.twig")
      */
     public function mentalCapacityAction(Request $request, $reportId)
     {

--- a/src/AppBundle/Controller/Report/DeputyExpenseController.php
+++ b/src/AppBundle/Controller/Report/DeputyExpenseController.php
@@ -19,7 +19,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/deputy-expenses", name="deputy_expenses")
-     * @Template()
+     * @Template("AppBundle:Report/DeputyExpense:start.html.twig")
      *
      * @param int $reportId
      *
@@ -40,7 +40,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/deputy-expenses/exist", name="deputy_expenses_exist")
-     * @Template()
+     * @Template("AppBundle:Report/DeputyExpense:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -75,7 +75,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/deputy-expenses/add", name="deputy_expenses_add")
-     * @Template()
+     * @Template("AppBundle:Report/DeputyExpense:add.html.twig")
      */
     public function addAction(Request $request, $reportId)
     {
@@ -113,7 +113,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/deputy-expenses/add_another", name="deputy_expenses_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/DeputyExpense:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -139,7 +139,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/deputy-expenses/edit/{expenseId}", name="deputy_expenses_edit")
-     * @Template()
+     * @Template("AppBundle:Report/DeputyExpense:edit.html.twig")
      */
     public function editAction(Request $request, $reportId, $expenseId)
     {
@@ -193,7 +193,7 @@ class DeputyExpenseController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/deputy-expenses/summary", name="deputy_expenses_summary")
-     * @Template()
+     * @Template("AppBundle:Report/DeputyExpense:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/DocumentController.php
+++ b/src/AppBundle/Controller/Report/DocumentController.php
@@ -28,7 +28,7 @@ class DocumentController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/documents", name="documents")
-     * @Template()
+     * @Template("AppBundle:Report/Document:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -50,7 +50,7 @@ class DocumentController extends AbstractController
     /**
      * @Route("/report/{reportId}/documents/step", name="documents_stepzero")
      * @Route("/report/{reportId}/documents/step/1", name="documents_step")
-     * @Template()
+     * @Template("AppBundle:Report/Document:step1.html.twig")
      */
     public function step1Action(Request $request, $reportId)
     {
@@ -101,7 +101,7 @@ class DocumentController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/documents/step/2", name="report_documents", defaults={"what"="new"})
-     * @Template()
+     * @Template("AppBundle:Report/Document:step2.html.twig")
      */
     public function step2Action(Request $request, $reportId)
     {
@@ -184,7 +184,7 @@ class DocumentController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/documents/summary", name="report_documents_summary")
-     * @Template()
+     * @Template("AppBundle:Report/Document:summary.html.twig")
      */
     public function summaryAction(Request $request, $reportId)
     {
@@ -239,7 +239,6 @@ class DocumentController extends AbstractController
      * Removes a document, adds a flash message and redirects to page
      *
      * @Route("/document/{documentId}/delete/confirm", name="delete_document_confirm")
-     * @Template()
      */
     public function deleteConfirmedAction(Request $request, $documentId)
     {

--- a/src/AppBundle/Controller/Report/GiftController.php
+++ b/src/AppBundle/Controller/Report/GiftController.php
@@ -20,7 +20,7 @@ class GiftController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/gifts", name="gifts")
-     * @Template()
+     * @Template("AppBundle:Report/Gift:start.html.twig")
      *
      * @param int $reportId
      *
@@ -41,7 +41,7 @@ class GiftController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/gifts/exist", name="gifts_exist")
-     * @Template()
+     * @Template("AppBundle:Report/Gift:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -76,7 +76,7 @@ class GiftController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/gifts/add", name="gifts_add")
-     * @Template()
+     * @Template("AppBundle:Report/Gift:add.html.twig")
      */
     public function addAction(Request $request, $reportId)
     {
@@ -118,7 +118,7 @@ class GiftController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/gifts/edit/{giftId}", name="gifts_edit")
-     * @Template()
+     * @Template("AppBundle:Report/Gift:edit.html.twig")
      */
     public function editAction(Request $request, $reportId, $giftId)
     {
@@ -168,7 +168,7 @@ class GiftController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/gifts/summary", name="gifts_summary")
-     * @Template()
+     * @Template("AppBundle:Report/Gift:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/LifestyleController.php
+++ b/src/AppBundle/Controller/Report/LifestyleController.php
@@ -19,7 +19,7 @@ class LifestyleController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/lifestyle", name="lifestyle")
-     * @Template()
+     * @Template("AppBundle:Report/Lifestyle:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -35,7 +35,7 @@ class LifestyleController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/lifestyle/step/{step}", name="lifestyle_step")
-     * @Template()
+     * @Template("AppBundle:Report/Lifestyle:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step)
     {
@@ -93,7 +93,7 @@ class LifestyleController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/lifestyle/summary", name="lifestyle_summary")
-     * @Template()
+     * @Template("AppBundle:Report/Lifestyle:summary.html.twig")
      */
     public function summaryAction(Request $request, $reportId)
     {

--- a/src/AppBundle/Controller/Report/MoneyInController.php
+++ b/src/AppBundle/Controller/Report/MoneyInController.php
@@ -22,7 +22,7 @@ class MoneyInController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in", name="money_in")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyIn:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -38,7 +38,7 @@ class MoneyInController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in/step{step}/{transactionId}", name="money_in_step", requirements={"step":"\d+"})
-     * @Template()
+     * @Template("AppBundle:Report/MoneyIn:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step, $transactionId = null)
     {
@@ -136,7 +136,7 @@ class MoneyInController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in/add_another", name="money_in_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyIn:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -164,7 +164,7 @@ class MoneyInController extends AbstractController
      * @Route("/report/{reportId}/money-in/summary", name="money_in_summary")
      *
      * @param int $reportId
-     * @Template()
+     * @Template("AppBundle:Report/MoneyIn:summary.html.twig")
      *
      * @return array
      */

--- a/src/AppBundle/Controller/Report/MoneyInShortController.php
+++ b/src/AppBundle/Controller/Report/MoneyInShortController.php
@@ -20,7 +20,7 @@ class MoneyInShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in-short", name="money_in_short")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyInShort:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -37,7 +37,7 @@ class MoneyInShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in-short/category", name="money_in_short_category")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyInShort:category.html.twig")
      */
     public function categoryAction(Request $request, $reportId)
     {
@@ -74,7 +74,7 @@ class MoneyInShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in-short/exist", name="money_in_short_exist")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyInShort:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -105,7 +105,7 @@ class MoneyInShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in-short/add", name="money_in_short_add")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyInShort:add.html.twig")
      */
     public function addAction(Request $request, $reportId)
     {
@@ -136,7 +136,7 @@ class MoneyInShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in-short/add_another", name="money_in_short_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyInShort:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -162,7 +162,7 @@ class MoneyInShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in-short/edit/{transactionId}", name="money_in_short_edit")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyInShort:edit.html.twig")
      */
     public function editAction(Request $request, $reportId, $transactionId)
     {
@@ -211,7 +211,7 @@ class MoneyInShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-in-short/summary", name="money_in_short_summary")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyInShort:summary.html.twig")
      */
     public function summaryAction(Request $request, $reportId)
     {

--- a/src/AppBundle/Controller/Report/MoneyOutController.php
+++ b/src/AppBundle/Controller/Report/MoneyOutController.php
@@ -22,7 +22,7 @@ class MoneyOutController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out", name="money_out")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOut:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -38,7 +38,7 @@ class MoneyOutController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out/step{step}/{transactionId}", name="money_out_step", requirements={"step":"\d+"})
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOut:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step, $transactionId = null)
     {
@@ -132,7 +132,7 @@ class MoneyOutController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out/add_another", name="money_out_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOut:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -160,7 +160,7 @@ class MoneyOutController extends AbstractController
      * @Route("/report/{reportId}/money-out/summary", name="money_out_summary")
      *
      * @param int $reportId
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOut:summary.html.twig")
      *
      * @return array
      */

--- a/src/AppBundle/Controller/Report/MoneyOutShortController.php
+++ b/src/AppBundle/Controller/Report/MoneyOutShortController.php
@@ -21,7 +21,7 @@ class MoneyOutShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out-short", name="money_out_short")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOutShort:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -38,7 +38,7 @@ class MoneyOutShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out-short/category", name="money_out_short_category")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOutShort:category.html.twig")
      */
     public function categoryAction(Request $request, $reportId)
     {
@@ -74,7 +74,7 @@ class MoneyOutShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out-short/exist", name="money_out_short_exist")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOutShort:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -106,7 +106,7 @@ class MoneyOutShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out-short/add", name="money_out_short_add")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOutShort:add.html.twig")
      */
     public function addAction(Request $request, $reportId)
     {
@@ -137,7 +137,7 @@ class MoneyOutShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out-short/add_another", name="money_out_short_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOutShort:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -163,7 +163,7 @@ class MoneyOutShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out-short/edit/{transactionId}", name="money_out_short_edit")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOutShort:edit.html.twig")
      */
     public function editAction(Request $request, $reportId, $transactionId)
     {
@@ -212,7 +212,7 @@ class MoneyOutShortController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-out-short/summary", name="money_out_short_summary")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyOutShort:summary.html.twig")
      */
     public function summaryAction(Request $request, $reportId)
     {

--- a/src/AppBundle/Controller/Report/MoneyTransferController.php
+++ b/src/AppBundle/Controller/Report/MoneyTransferController.php
@@ -20,7 +20,7 @@ class MoneyTransferController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-transfers", name="money_transfers")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyTransfer:start.html.twig")
      *
      * @param int $reportId
      *
@@ -47,7 +47,7 @@ class MoneyTransferController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-transfers/exist", name="money_transfers_exist")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyTransfer:exist.html.twig")
      */
     public function existAction(Request $request, $reportId)
     {
@@ -84,7 +84,7 @@ class MoneyTransferController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-transfers/step{step}/{transferId}", name="money_transfers_step", requirements={"step":"\d+"})
-     * @Template()
+     * @Template("AppBundle:Report/MoneyTransfer:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step, $transferId = null)
     {
@@ -170,7 +170,7 @@ class MoneyTransferController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-transfers/add_another", name="money_transfers_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyTransfer:addAnother.html.twig")
      */
     public function addAnotherAction(Request $request, $reportId)
     {
@@ -196,7 +196,7 @@ class MoneyTransferController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/money-transfers/summary", name="money_transfers_summary")
-     * @Template()
+     * @Template("AppBundle:Report/MoneyTransfer:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/OtherInfoController.php
+++ b/src/AppBundle/Controller/Report/OtherInfoController.php
@@ -20,7 +20,7 @@ class OtherInfoController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/any-other-info", name="other_info")
-     * @Template()
+     * @Template("AppBundle:Report/OtherInfo:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -36,7 +36,7 @@ class OtherInfoController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/any-other-info/step/{step}", name="other_info_step")
-     * @Template()
+     * @Template("AppBundle:Report/OtherInfo:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step)
     {
@@ -81,7 +81,7 @@ class OtherInfoController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/any-other-info/summary", name="other_info_summary")
-     * @Template()
+     * @Template("AppBundle:Report/OtherInfo:summary.html.twig")
      */
     public function summaryAction(Request $request, $reportId)
     {

--- a/src/AppBundle/Controller/Report/PaFeeExpenseController.php
+++ b/src/AppBundle/Controller/Report/PaFeeExpenseController.php
@@ -24,7 +24,7 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("", name="pa_fee_expense")
-     * @Template()
+     * @Template("AppBundle:Report/PaFeeExpense:start.html.twig")
      *
      * @param int $reportId
      *
@@ -45,7 +45,7 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("/fee-exist", name="pa_fee_expense_fee_exist")
-     * @Template()
+     * @Template("AppBundle:Report/PaFeeExpense:feeExist.html.twig")
      */
     public function feeExistAction(Request $request, $reportId)
     {
@@ -79,7 +79,7 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("/fee-edit", name="pa_fee_expense_fee_edit")
-     * @Template()
+     * @Template("AppBundle:Report/PaFeeExpense:feeEdit.html.twig")
      */
     public function feeEditAction(Request $request, $reportId)
     {
@@ -111,7 +111,7 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("/other/exist", name="pa_fee_expense_other_exist")
-     * @Template()
+     * @Template("AppBundle:Report/PaFeeExpense:otherExist.html.twig")
      */
     public function otherExistAction(Request $request, $reportId)
     {
@@ -151,7 +151,7 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("/other/add", name="pa_fee_expense_other_add")
-     * @Template()
+     * @Template("AppBundle:Report/PaFeeExpense:otherAdd.html.twig")
      */
     public function otherAddAction(Request $request, $reportId)
     {
@@ -194,7 +194,7 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("/other/add-another", name="pa_fee_expense_add_another")
-     * @Template()
+     * @Template("AppBundle:Report/PaFeeExpense:otherAddAnother.html.twig")
      */
     public function otherAddAnotherAction(Request $request, $reportId)
     {
@@ -220,7 +220,7 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("/other-edit/{expenseId}", name="pa_fee_expense_edit")
-     * @Template()
+     * @Template("AppBundle:Report/PaFeeExpense:otherEdit.html.twig")
      *
      * @param Request $request
      * @param $reportId
@@ -261,7 +261,6 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("/other/delete/{expenseId}", name="pa_fee_expense_delete")
-     * @Template()
      *
      * @param Request $request
      * @param $reportId
@@ -284,7 +283,7 @@ class PaFeeExpenseController extends AbstractController
 
     /**
      * @Route("/summary", name="pa_fee_expense_summary")
-     * @Template()
+     * @Template("AppBundle:Report/PaFeeExpense:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/ProfCurrentFeesController.php
+++ b/src/AppBundle/Controller/Report/ProfCurrentFeesController.php
@@ -26,7 +26,7 @@ class ProfCurrentFeesController extends AbstractController
 
     /**
      * @Route("", name="prof_current_fees")
-     * @Template()
+     * @Template("AppBundle:Report/ProfCurrentFees:start.html.twig")
      *
      * @param int $reportId
      *
@@ -46,7 +46,7 @@ class ProfCurrentFeesController extends AbstractController
 
     /**
      * @Route("/exist", name="prof_current_fees_exist")
-     * @Template()
+     * @Template("AppBundle:Report/ProfCurrentFees:exist.html.twig")
      *
      * @param int $reportId
      */
@@ -82,7 +82,7 @@ class ProfCurrentFeesController extends AbstractController
 
     /**
      * @Route("/step/{step}/{feeId}", name="current_service_fee_step", requirements={"step":"\d+"})
-     * @Template()
+     * @Template("AppBundle:Report/ProfCurrentFees:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step, $feeId = null)
     {
@@ -201,7 +201,7 @@ class ProfCurrentFeesController extends AbstractController
 
     /**
      * @Route("/previous-estimates/fee/{feeId}", name="previous_estimates")
-     * @Template()
+     * @Template("AppBundle:Report/ProfCurrentFees:previousEstimates.html.twig")
      *
      * @param int $reportId
      *
@@ -242,7 +242,7 @@ class ProfCurrentFeesController extends AbstractController
 
     /**
      * @Route("/summary", name="prof_service_fees_summary")
-     * @Template()
+     * @Template("AppBundle:Report/ProfCurrentFees:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/ProfDeputyCostsController.php
+++ b/src/AppBundle/Controller/Report/ProfDeputyCostsController.php
@@ -30,7 +30,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("", name="prof_deputy_costs")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:start.html.twig")
      *
      * @param int $reportId
      * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
@@ -52,7 +52,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/how-charged", name="prof_deputy_costs_how_charged")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:howCharged.html.twig")
      */
     public function howChargedAction(Request $request, $reportId)
     {
@@ -87,7 +87,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/previous-received-exists", name="prof_deputy_costs_previous_received_exists")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:previousReceivedExists.html.twig")
      */
     public function previousReceivedExists(Request $request, $reportId)
     {
@@ -134,7 +134,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/previous-received/{previousReceivedId}", name="prof_deputy_costs_previous_received")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:previousReceived.html.twig")
      */
     public function previousReceived(Request $request, $reportId, $previousReceivedId = null)
     {
@@ -185,7 +185,6 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/previous-received/{previousReceivedId}/delete", name="prof_deputy_costs_previous_received_delete")
-     * @Template()
      *
      * @param Request $request
      * @param $reportId
@@ -209,7 +208,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/interim-exists", name="prof_deputy_costs_inline_interim_19b_exists")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:interimExists.html.twig")
      */
     public function interimExists(Request $request, $reportId)
     {
@@ -256,7 +255,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/interim", name="prof_deputy_costs_inline_interim_19b")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:interim.html.twig")
      */
     public function interim(Request $request, $reportId)
     {
@@ -293,7 +292,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/costs-received", name="prof_deputy_costs_received")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:fixedCost.html.twig")
      */
     public function fixedCostAction(Request $request, $reportId)
     {
@@ -331,7 +330,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/amount-scco", name="prof_deputy_costs_amount_scco")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:amountToScco.html.twig")
      */
     public function amountToSccoAction(Request $request, $reportId)
     {
@@ -365,7 +364,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/breakdown", name="prof_deputy_costs_breakdown")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:breakdown.html.twig")
      */
     public function breakdown(Request $request, $reportId)
     {
@@ -434,7 +433,7 @@ class ProfDeputyCostsController extends AbstractController
 
     /**
      * @Route("/summary", name="prof_deputy_costs_summary")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCosts:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/ProfDeputyCostsEstimateController.php
+++ b/src/AppBundle/Controller/Report/ProfDeputyCostsEstimateController.php
@@ -28,7 +28,7 @@ class ProfDeputyCostsEstimateController extends AbstractController
 
     /**
      * @Route("", name="prof_deputy_costs_estimate")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCostsEstimate:start.html.twig")
      *
      * @param $reportId
      * @return array|\Symfony\Component\HttpFoundation\RedirectResponse
@@ -50,7 +50,7 @@ class ProfDeputyCostsEstimateController extends AbstractController
 
     /**
      * @Route("/how-charged", name="prof_deputy_costs_estimate_how_charged")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCostsEstimate:howCharged.html.twig")
      *
      * @param Request $request
      * @param $reportId
@@ -87,7 +87,7 @@ class ProfDeputyCostsEstimateController extends AbstractController
 
     /**
      * @Route("/breakdown", name="prof_deputy_costs_estimate_breakdown")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCostsEstimate:breakdown.html.twig")
      */
     public function breakdownAction(Request $request, $reportId)
     {
@@ -126,7 +126,7 @@ class ProfDeputyCostsEstimateController extends AbstractController
 
     /**
      * @Route("/more-info", name="prof_deputy_costs_estimate_more_info")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCostsEstimate:moreInfo.html.twig")
      */
     public function moreInfoAction(Request $request, $reportId)
     {
@@ -155,7 +155,7 @@ class ProfDeputyCostsEstimateController extends AbstractController
 
     /**
      * @Route("/summary", name="prof_deputy_costs_estimate_summary")
-     * @Template()
+     * @Template("AppBundle:Report/ProfDeputyCostsEstimate:summary.html.twig")
      *
      * @param int $reportId
      *

--- a/src/AppBundle/Controller/Report/ReportController.php
+++ b/src/AppBundle/Controller/Report/ReportController.php
@@ -83,7 +83,7 @@ class ReportController extends AbstractController
      *
      * @Route("/lay", name="lay_home")
      * //TODO we should add Security("has_role('ROLE_LAY_DEPUTY')") here, but not sure as not clear what "getCorrectRouteIfDifferent" does
-     * @Template()
+     * @Template("AppBundle:Report/Report:index.html.twig")
      */
     public function indexAction(Request $request)
     {
@@ -117,7 +117,7 @@ class ReportController extends AbstractController
      * Edit single report
      *
      * @Route("/reports/edit/{reportId}", name="report_edit")
-     * @Template()
+     * @Template("AppBundle:Report/Report:edit.html.twig")
      */
     public function editAction(Request $request, $reportId)
     {
@@ -189,7 +189,7 @@ class ReportController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/overview", name="report_overview")
-     * @Template()
+     * @Template("AppBundle:Report/Report:overview.html.twig")
      */
     public function overviewAction(Request $request, $reportId)
     {
@@ -287,7 +287,7 @@ class ReportController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/declaration", name="report_declaration")
-     * @Template()
+     * @Template("AppBundle:Report/Report:declaration.html.twig")
      */
     public function declarationAction(Request $request, $reportId)
     {
@@ -328,7 +328,7 @@ class ReportController extends AbstractController
      * Page displaying the report has been submitted.
      *
      * @Route("/report/{reportId}/submitted", name="report_submit_confirmation")
-     * @Template()
+     * @Template("AppBundle:Report/Report:submitConfirmation.html.twig")
      */
     public function submitConfirmationAction(Request $request, $reportId)
     {
@@ -361,7 +361,7 @@ class ReportController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/submit_feedback", name="report_submit_feedback")
-     * @Template()
+     * @Template("AppBundle:Report/Report:submitFeedback.html.twig")
      */
     public function submitFeedbackAction($reportId)
     {
@@ -384,7 +384,7 @@ class ReportController extends AbstractController
      * Used for active and archived report.
      *
      * @Route("/report/{reportId}/review", name="report_review")
-     * @Template()
+     * @Template("AppBundle:Report/Report:review.html.twig")
      */
     public function reviewAction($reportId)
     {

--- a/src/AppBundle/Controller/Report/ReportController.php
+++ b/src/AppBundle/Controller/Report/ReportController.php
@@ -154,7 +154,7 @@ class ReportController extends AbstractController
      *   defaults={ "action" = "create"},
      *   requirements={ "action" = "(create|add)"}
      * )
-     * @Template()
+     * @Template("AppBundle:Report/Report:create.html.twig")
      */
     public function createAction(Request $request, $clientId, $action = false)
     {

--- a/src/AppBundle/Controller/Report/VisitsCareController.php
+++ b/src/AppBundle/Controller/Report/VisitsCareController.php
@@ -20,7 +20,7 @@ class VisitsCareController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/visits-care", name="visits_care")
-     * @Template()
+     * @Template("AppBundle:Report/VisitsCare:start.html.twig")
      */
     public function startAction(Request $request, $reportId)
     {
@@ -36,7 +36,7 @@ class VisitsCareController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/visits-care/step/{step}", name="visits_care_step")
-     * @Template()
+     * @Template("AppBundle:Report/VisitsCare:step.html.twig")
      */
     public function stepAction(Request $request, $reportId, $step)
     {
@@ -95,7 +95,7 @@ class VisitsCareController extends AbstractController
 
     /**
      * @Route("/report/{reportId}/visits-care/summary", name="visits_care_summary")
-     * @Template()
+     * @Template("AppBundle:Report/VisitsCare:summary.html.twig")
      */
     public function summaryAction(Request $request, $reportId)
     {

--- a/src/AppBundle/Controller/SettingsController.php
+++ b/src/AppBundle/Controller/SettingsController.php
@@ -16,7 +16,7 @@ class SettingsController extends AbstractController
     /**
      * @Route("/deputyship-details", name="account_settings")
      * @Route("/org/settings", name="org_settings")
-     * @Template()
+     * @Template("AppBundle:Settings:index.html.twig")
      **/
     public function indexAction()
     {
@@ -40,7 +40,7 @@ class SettingsController extends AbstractController
     /**
      * @Route("/deputyship-details/your-details/change-password", name="user_password_edit")
      * @Route("/org/settings/your-details/change-password", name="org_profile_password_edit")
-     * @Template()
+     * @Template("AppBundle:Settings:passwordEdit.html.twig")
      */
     public function passwordEditAction(Request $request)
     {
@@ -70,7 +70,7 @@ class SettingsController extends AbstractController
 
     /**
      * @Route("/deputyship-details/your-details/change-password/done", name="user_password_edit_done")
-     * @Template()
+     * @Template("AppBundle:Settings:passwordEditDone.html.twig")
      */
     public function passwordEditDoneAction(Request $request)
     {
@@ -96,7 +96,7 @@ class SettingsController extends AbstractController
      *
      * @Route("/deputyship-details/your-details/edit", name="user_edit")
      * @Route("/org/settings/your-details/edit", name="org_profile_edit")
-     * @Template()
+     * @Template("AppBundle:Settings:profileEdit.html.twig")
      * @throw AccessDeniedException
      **/
     public function profileEditAction(Request $request)

--- a/src/AppBundle/Controller/SettingsController.php
+++ b/src/AppBundle/Controller/SettingsController.php
@@ -82,7 +82,7 @@ class SettingsController extends AbstractController
      *
      * @Route("/deputyship-details/your-details", name="user_show")
      * @Route("/org/settings/your-details", name="org_profile_show")
-     * @Template()
+     * @Template("AppBundle:Settings:profile.html.twig")
      **/
     public function profileAction()
     {

--- a/src/AppBundle/Controller/UserController.php
+++ b/src/AppBundle/Controller/UserController.php
@@ -22,7 +22,6 @@ class UserController extends AbstractController
      * @Route("/user/{action}/{token}", name="user_activate", defaults={ "action" = "activate"}, requirements={
      *   "action" = "(activate|password-reset)"
      * })
-     * @Template()
      */
     public function activateUserAction(Request $request, $action, $token)
     {
@@ -104,7 +103,7 @@ class UserController extends AbstractController
 
     /**
      * @Route("/user/activate/password/send/{token}", name="activation_link_send")
-     * @Template()
+     * @Template("AppBundle:User:activateLinkSend.html.twig")
      */
     public function activateLinkSendAction(Request $request, $token)
     {
@@ -124,7 +123,7 @@ class UserController extends AbstractController
 
     /**
      * @Route("/user/activate/password/sent/{token}", name="activation_link_sent")
-     * @Template()
+     * @Template("AppBundle:User:activateLinkSent.html.twig")
      */
     public function activateLinkSentAction(Request $request, $token)
     {
@@ -143,7 +142,7 @@ class UserController extends AbstractController
      * - PA
      *
      * @Route("/user/details", name="user_details")
-     * @Template()
+     * @Template("AppBundle:User:details.html.twig")
      */
     public function detailsAction(Request $request)
     {
@@ -176,7 +175,7 @@ class UserController extends AbstractController
 
     /**
      * @Route("/password-managing/forgotten", name="password_forgotten")
-     * @Template()
+     * @Template("AppBundle:User:passwordForgotten.html.twig")
      **/
     public function passwordForgottenAction(Request $request)
     {
@@ -219,7 +218,7 @@ class UserController extends AbstractController
 
     /**
      * @Route("/password-managing/sent", name="password_sent")
-     * @Template()
+     * @Template("AppBundle:User:passwordSent.html.twig")
      **/
     public function passwordSentAction()
     {
@@ -228,7 +227,7 @@ class UserController extends AbstractController
 
     /**
      * @Route("/register", name="register")
-     * @Template()
+     * @Template("AppBundle:User:register.html.twig")
      */
     public function registerAction(Request $request)
     {
@@ -302,7 +301,6 @@ class UserController extends AbstractController
 
     /**
      * @Route("/user/agree-terms-use/{token}", name="user_agree_terms_use")
-     * @Template()
      */
     public function agreeTermsUseAction(Request $request, $token)
     {


### PR DESCRIPTION
## Purpose
Bump `sensio\framework-extra-bundle` to latest major version 5.

**Breaking change**
The upgrade from v3 to v5 contains a breaking change with regards to how template files are located when using the @Template() annotation. If no path is given, it relies on the TemplateGuesser to guess where it is, which now presumes them to live in lower cased and underscored directories.

See [gihub issue](https://github.com/sensiolabs/SensioFrameworkExtraBundle/issues/538)

Fixes [DDPB-2792](https://opgtransform.atlassian.net/browse/DDPB-2792)

## Approach


Given that our code contains a huge number of explicit references to the files at their current paths, I suggest that instead of updating all directory and filenames, we explicitly pass the current paths into the @Template() annotation. This removes any future reliance on the TemplateGuesser, makes it easier for devs to locate the template files, and is generally considered a better practice.

## Learning


## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [N/A] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [ ] The product team have tested these changes

### For each page changed
- [ ] I have run an in-browser accessibility test (e.g. WAVE, Lighthouse)
- [ ] There are no deprecated CSS classes noted in the profiler
- [ ] Translations are used and the profiler doesn't identify any missing
