### PR TITLE
Reinstate "main-content" ID on <main>

### DIFF
--- a/client/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
+++ b/client/src/AppBundle/Resources/views/Layouts/moj_template.html.twig
@@ -109,7 +109,7 @@
 
         {% block linkBack %}{% endblock %}
 
-        <main class="govuk-main-wrapper" role="main">
+        <main id="main-content" class="govuk-main-wrapper" role="main">
             {% block content %}{% endblock %}
         </main>
     </div>


### PR DESCRIPTION
I originally did this as part of DDPB-2589, but overwrote it when merging from master 🙄

It's necessary for the skip link to work for keyboard users