### PR TITLE
DDPB-2714: Fix display issues with assets

### DIFF
--- a/client/src/AppBundle/Resources/views/Ndr/Asset/_list.html.twig
+++ b/client/src/AppBundle/Resources/views/Ndr/Asset/_list.html.twig
@@ -20,7 +20,7 @@
         {{ 'existPage.form.noAssetToAdd.label' | trans(transOptions)  }}
     </dt>
     <dd class="govuk-summary-list__value">
-        {{ ndr.noAssetToAdd ? 'Yes' : 'No' }}
+        {{ ndr.noAssetToAdd ? 'No' : 'Yes' }}
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link behat-link-edit" href="{{ url('ndr_assets_exist', { 'ndrId': ndr.id, 'from': 'summary' }) }}">

--- a/client/tests/behat/features/deputy/02-ndr/05-assets.feature
+++ b/client/tests/behat/features/deputy/02-ndr/05-assets.feature
@@ -58,6 +58,7 @@ Feature: NDR assets
     And I choose "no" when asked for adding another record
       # check record in summary page
     And each text should be present in the corresponding region:
+      | Yes                    | has-assets                   |
       | Alfa Romeo 156 JTD     | asset-alfa-romeo-156-jtd     |
       | £17,000.00             | asset-alfa-romeo-156-jtd     |
       | 12 January 2016        | asset-alfa-romeo-156-jtd     |

--- a/client/tests/behat/features/deputy/03-report/01-102/13-asset.feature
+++ b/client/tests/behat/features/deputy/03-report/01-102/13-asset.feature
@@ -59,6 +59,7 @@ Feature: Report asset with variations
         And I choose "no" when asked for adding another record
         # check record in summary page
         And each text should be present in the corresponding region:
+            | Yes | has-assets |
             | Alfa Romeo 156 JTD | asset-alfa-romeo-156-jtd |
             | £17,000.00 | asset-alfa-romeo-156-jtd |
             | 12 January 2016 | asset-alfa-romeo-156-jtd |


### PR DESCRIPTION
## Purpose
An issue was raised during testing of DDPB-2714 which was fixed incorrectly. This PR undoes the incorrect fix and adds tests to emulate the issue. The [API PR](https://github.com/ministryofjustice/opg-digi-deps-api/pull/574) fixes the problem.

Fixes [DDPB-2714](https://opgtransform.atlassian.net/browse/DDPB-2714)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have updated documentation (Confluence/GitHub wiki/tech debt doc) where relevant
- [x] I have added tests to prove my work, and they follow our [best practices](https://github.com/ministryofjustice/opg-digi-deps-client/wiki/Testing-best-practices)
- [x] I have successfully built my branch to a feature environment
- [x] New and existing unit tests pass locally with my changes (`docker-compose run --rm test sh scripts/clienttest.sh`)
- [x] There are no new frontend linting errors (`docker-compose run --rm npm run lint`)
- [x] There are no NPM security issues (`docker-compose run --rm npm audit`)
- [x] There are no Composer security issues (`docker-compose run frontend php app/console security:check`)
- [x] The product team have tested these changes
  - N/A